### PR TITLE
Feature/add libks support (#3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 # to build module you will need
 # apt-get update && apt-get install -y build-essential cmake pkg-config libfreeswitch-dev libspeexdsp-dev libssl-dev
-# mkdir -p build 
+# mkdir -p build
 # cd build
 # cmake -DCMAKE_BUILD_TYPE=Release ..
 # make
+#
+# Optional WebSocket support requires libks or libks2 (pkg-config).
 
 cmake_minimum_required(VERSION 3.18)
 project(mod_janus)
@@ -13,18 +15,44 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "")
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(FreeSWITCH REQUIRED IMPORTED_TARGET freeswitch)
 pkg_get_variable(FS_MOD_DIR freeswitch modulesdir)
-message("FreeSWITCH modules dir: ${FS_MOD_DIR}")
+message(STATUS "FreeSWITCH modules dir: ${FS_MOD_DIR}")
 
 # HMAC-SHA1 / base64 for Janus signed-token generation (auth.c).
 find_package(OpenSSL REQUIRED)
 
-add_library(mod_janus SHARED globals.c cJSON.c http.c api.c servers.c hash.c auth.c mod_janus.c)
+set(JANUS_SOURCES
+	globals.c
+	cJSON.c
+	http.c
+	api.c
+	servers.c
+	hash.c
+	auth.c
+	mod_janus.c
+)
 
-
+add_library(mod_janus SHARED ${JANUS_SOURCES})
 set_property(TARGET mod_janus PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-
 target_link_libraries(mod_janus PRIVATE PkgConfig::FreeSWITCH OpenSSL::Crypto pthread)
 
+pkg_check_modules(KS2 libks2 IMPORTED_TARGET)
+if(KS2_FOUND)
+	message(STATUS "libks2 found: WebSocket support enabled")
+	target_sources(mod_janus PRIVATE janus_ws.c)
+	target_link_libraries(mod_janus PRIVATE PkgConfig::KS2)
+	target_compile_definitions(mod_janus PRIVATE HAVE_MOD_JANUS_WS=1)
+	target_compile_options(mod_janus PRIVATE ${KS2_CFLAGS})
+else()
+	pkg_check_modules(KS1 libks IMPORTED_TARGET)
+	if(KS1_FOUND)
+		message(STATUS "libks found: WebSocket support enabled")
+		target_sources(mod_janus PRIVATE janus_ws.c)
+		target_link_libraries(mod_janus PRIVATE PkgConfig::KS1)
+		target_compile_definitions(mod_janus PRIVATE HAVE_MOD_JANUS_WS=1)
+		target_compile_options(mod_janus PRIVATE ${KS1_CFLAGS})
+	else()
+		message(STATUS "libks not found: build is HTTP-only; ws:// URLs in config will be rejected at load time")
+	endif()
+endif()
 
 install(TARGETS mod_janus DESTINATION ${FS_MOD_DIR})

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,11 @@ LIBS := $(if $(switch_builddir),$(switch_builddir)/libfreeswitch.la,)
 
 mod_LTLIBRARIES = mod_janus.la
 mod_janus_la_SOURCES  = globals.c cJSON.c http.c api.c servers.c hash.c auth.c mod_janus.c
-mod_janus_la_CFLAGS   = $(AM_CFLAGS) $(FREESWITCH_CFLAGS)
+mod_janus_la_CFLAGS   = $(AM_CFLAGS) $(FREESWITCH_CFLAGS) $(KS_CFLAGS)
 mod_janus_la_LDFLAGS  = -avoid-version -module -no-undefined -shared $(FREESWITCH_LIBS) $(OPENSSL_LIBS) $(MOSQUITTO_LIBS)
-mod_janus_la_LIBADD   = $(LIBS)
+mod_janus_la_LIBADD   = $(LIBS) $(KS_LIBS)
+
+if HAVE_KS
+mod_janus_la_SOURCES += janus_ws.c
+mod_janus_la_CFLAGS += -DHAVE_MOD_JANUS_WS=1
+endif

--- a/api.c
+++ b/api.c
@@ -37,9 +37,13 @@
 // use switch_stun_random_string() to get a transactionId
 #include  "switch_stun.h"
 #include  "globals.h"
+#include  "servers.h"
 #include  "http.h"
 #include  "auth.h"
 #include  "api.h"
+#if defined(HAVE_MOD_JANUS_WS)
+#include  "janus_ws.h"
+#endif
 
 #define TRANSACTION_ID_LENGTH 16
 #define JANUS_STRING  "janus"
@@ -55,6 +59,31 @@
  * today; bump this if we ever need more.
  */
 #define MAX_TOKEN_DESCRIPTORS 4
+
+/*
+ * URL flavour for HTTP transport. WS transport ignores this and adds the
+ * session_id / handle_id into the JSON body instead.
+ */
+typedef enum {
+	URL_ROOT,    /* pUrl                            (create)              */
+	URL_SESSION, /* pUrl/<serverId>                 (claim, attach)       */
+	URL_HANDLE   /* pUrl/<serverId>/<senderId>      (everything handle)   */
+} api_url_kind_t;
+
+#if defined(HAVE_MOD_JANUS_WS)
+/*
+ * Add a uint64 field as a raw JSON integer. cJSON stores numbers as `double`
+ * and its printer may fall back to `%1.15g` (e.g. "8.31461053888952e+15"),
+ * which Janus/Jansson parses as a JSON real and rejects for integer-only
+ * fields like session_id / handle_id. Emit the value verbatim instead.
+ */
+static void api_ws_add_u64(cJSON *root, const char *name, uint64_t value)
+{
+	char buf[32];
+	(void) snprintf(buf, sizeof(buf), "%" SWITCH_UINT64_T_FMT, value);
+	cJSON_AddRawToObject(root, name, buf);
+}
+#endif
 
 typedef struct {
 	const char *pType;
@@ -134,31 +163,34 @@ static cJSON *encode(const message_t message) {
 		 */
 		const char *pDescriptors[MAX_TOKEN_DESCRIPTORS + 1];
 		int ndesc = 0;
+		int i;
 		pDescriptors[ndesc++] = JANUS_PLUGIN;
-		for (int i = 0; i < message.nExtraDescriptors && ndesc <= MAX_TOKEN_DESCRIPTORS; i++) {
+		for (i = 0; i < message.nExtraDescriptors && ndesc <= MAX_TOKEN_DESCRIPTORS; i++) {
 			if (message.pExtraDescriptors[i] && *message.pExtraDescriptors[i]) {
 				pDescriptors[ndesc++] = message.pExtraDescriptors[i];
 			}
 		}
 
-		int ttl = message.hmacTokenTtl > 0 ? message.hmacTokenTtl : API_HMAC_DEFAULT_LIFECYCLE_TTL;
-		char *pToken = authSignToken(message.pHmacSecret, ttl, pDescriptors, ndesc);
-		if (!pToken) {
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Cannot sign token\n");
-			goto error;
-		}
+		{
+			int ttl = message.hmacTokenTtl > 0 ? message.hmacTokenTtl : API_HMAC_DEFAULT_LIFECYCLE_TTL;
+			char *pToken = authSignToken(message.pHmacSecret, ttl, pDescriptors, ndesc);
+			if (!pToken) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Cannot sign token\n");
+				goto error;
+			}
 
-		if (cJSON_AddStringToObject(pJsonRequest, "token", pToken) == NULL) {
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Cannot create string (token)\n");
-			free(pToken);
-			goto error;
-		}
+			if (cJSON_AddStringToObject(pJsonRequest, "token", pToken) == NULL) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Cannot create string (token)\n");
+				free(pToken);
+				goto error;
+			}
 
-		if (message.pSignedTokenOut) {
-			/* Hand ownership to the caller; they must free(). */
-			*message.pSignedTokenOut = pToken;
-		} else {
-			free(pToken);
+			if (message.pSignedTokenOut) {
+				/* Hand ownership to the caller; they must free(). */
+				*message.pSignedTokenOut = pToken;
+			} else {
+				free(pToken);
+			}
 		}
 	}
 
@@ -271,7 +303,7 @@ static message_t *decode(cJSON *pJsonResponse) {
 			return NULL;
 		} else {
 			pMessage->pType = pJsonRspJanus->valuestring;
-			DEBUG(SWITCH_CHANNEL_LOG, "janus=%s\n", pMessage->pType);
+			MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "janus=%s\n", pMessage->pType);
 		}
 	}
 
@@ -282,7 +314,7 @@ static message_t *decode(cJSON *pJsonResponse) {
 			return NULL;
 		} else {
 			pMessage->pTransactionId = pJsonRspTransaction->valuestring;
-			DEBUG(SWITCH_CHANNEL_LOG, "transaction=%s\n", pMessage->pTransactionId);
+			MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "transaction=%s\n", pMessage->pTransactionId);
 		}
 	}
 
@@ -293,7 +325,7 @@ static message_t *decode(cJSON *pJsonResponse) {
 			return NULL;
 		} else {
 			pMessage->serverId = (janus_id_t) pJsonRspServerId->valuedouble;
-			DEBUG(SWITCH_CHANNEL_LOG, "serverId=%" SWITCH_UINT64_T_FMT "\n", pMessage->serverId);
+			MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "serverId=%" SWITCH_UINT64_T_FMT "\n", pMessage->serverId);
 		}
 	}
 
@@ -304,39 +336,263 @@ static message_t *decode(cJSON *pJsonResponse) {
 			return NULL;
 		} else {
 			pMessage->senderId = (janus_id_t) pJsonRspSender->valuedouble;
-			DEBUG(SWITCH_CHANNEL_LOG, "sender=%" SWITCH_UINT64_T_FMT "\n", pMessage->senderId);
+			MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "sender=%" SWITCH_UINT64_T_FMT "\n", pMessage->senderId);
 		}
 	}
 
 	return pMessage;
 }
 
-janus_id_t apiGetServerId(const char *pUrl, const char *pSecret, const char *pHmacSecret) {
+/*
+ * Send one Janus request through the transport configured on pServer.
+ *   - WS: adds session_id/handle_id and (if set) the stored auth-token to the
+ *         request body, then calls janus_ws_rpc_json. Note: when pHmacSecret
+ *         is in use, encode() has already added the signed `token` field at
+ *         the top level, so we only need to add the stored token in non-HMAC
+ *         mode.
+ *   - HTTP: builds URL per `kind` and calls httpPost(HTTP_POST_TIMEOUT).
+ *
+ * Caller retains ownership of `pJsonRequest` and must cJSON_Delete() the
+ * returned response (or NULL on error).
+ */
+static cJSON *api_send_request(server_t *pServer, cJSON *pJsonRequest, const char *pTransactionId,
+	janus_id_t serverId, janus_id_t senderId, api_url_kind_t kind, const char *label)
+{
+#if defined(HAVE_MOD_JANUS_WS)
+	if (pServer->transport == JANUS_TP_WS) {
+		if (serverId) api_ws_add_u64(pJsonRequest, "session_id", (uint64_t) serverId);
+		if (senderId) api_ws_add_u64(pJsonRequest, "handle_id", (uint64_t) senderId);
+		/* Stored-mode token only; HMAC-signed token already added by encode(). */
+		if (!pServer->pHmacSecret && !zstr(pServer->pAuthToken)) {
+			cJSON_AddStringToObject(pJsonRequest, "token", pServer->pAuthToken);
+		}
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Sending WebSocket %s\n", label);
+		return janus_ws_rpc_json(pServer, pJsonRequest, pTransactionId,
+			(switch_interval_time_t) HTTP_POST_TIMEOUT * 1000);
+	}
+#else
+	(void) pTransactionId;
+#endif
+	{
+		char url[1024];
+		int n;
+		switch (kind) {
+		case URL_ROOT:
+			n = snprintf(url, sizeof(url), "%s", pServer->pUrl);
+			break;
+		case URL_SESSION:
+			n = snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT, pServer->pUrl, serverId);
+			break;
+		case URL_HANDLE:
+		default:
+			n = snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT "/%" SWITCH_UINT64_T_FMT,
+				pServer->pUrl, serverId, senderId);
+			break;
+		}
+		if (n < 0 || (size_t) n >= sizeof(url)) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Could not generate URL\n");
+			return NULL;
+		}
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Sending HTTP %s - url=%s\n", label, url);
+		return httpPost(url, HTTP_POST_TIMEOUT, pJsonRequest);
+	}
+}
+
+switch_status_t api_dispatch_poll_event(cJSON *pEvent,
+	switch_status_t (*pJoinedFunc)(const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const janus_id_t participantId),
+	switch_status_t (*pAcceptedFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pSdp),
+	switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
+	switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
+	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
+	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason))
+{
+	message_t *pResponse = NULL;
+	cJSON *pJsonRspReason;
+	cJSON *pJsonRspType;
+	cJSON *pJsonRspRoomId;
+	cJSON *pJsonRspParticipantId;
+	cJSON *pJsonRspJsepType;
+	cJSON *pJsonRspJsepSdp;
+	cJSON *pJsonRspError;
+	cJSON *pJsonRspErrorCode;
+
+	if (!(pResponse = decode(pEvent))) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response\n");
+		goto end_dispatch;
+	}
+
+	if (!strcmp(pResponse->pType, "keepalive")) {
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Its a keepalive - do nothing\n");
+	} else if (!strcmp(pResponse->pType, "ack")) {
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Janus ack (no-op)\n");
+	} else if (!strcmp(pResponse->pType, "hangup")) {
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Its an hangup\n");
+
+		pJsonRspReason = cJSON_GetObjectItemCaseSensitive(pEvent, "reason");
+		if (!cJSON_IsString(pJsonRspReason)) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (reason)\n");
+			goto end_dispatch;
+		}
+
+		if ((*pHungupFunc)(pResponse->serverId, pResponse->senderId, pJsonRspReason->valuestring)) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't hangup\n");
+		}
+	} else if (!strcmp(pResponse->pType, "detached")) {
+		if ((*pHungupFunc)(pResponse->serverId, pResponse->senderId, NULL)) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't detach\n");
+		}
+	} else if (!strcmp(pResponse->pType, "webrtcup")) {
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "WebRTC has been setup\n");
+		if (pAnswerOnWebrtcupFunc && pAnswerOnWebrtcupFunc(pResponse->serverId, pResponse->senderId)) {
+			if ((*pAnsweredFunc)(pResponse->serverId, pResponse->senderId)) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't answer (on webrtcup)\n");
+			}
+		}
+	} else if (!strcmp(pResponse->pType, "media")) {
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Media is flowing\n");
+	} else if (!strcmp(pResponse->pType, "trickle")) {
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Receieved a candidate\n");
+
+		if ((*pTrickleFunc)(pResponse->serverId, pResponse->senderId, pResponse->pCandidate)) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't add candidate\n");
+		}
+	} else if (!strcmp(pResponse->pType, "event")) {
+		pJsonRspType = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "audiobridge");
+		if (!cJSON_IsString(pJsonRspType)) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "No response (plugindata.data.audiobridge)\n");
+			goto end_dispatch;
+		}
+
+		if (!strcmp("joined", pJsonRspType->valuestring)) {
+			janus_id_t roomId;
+			janus_id_t participantId;
+
+			pJsonRspRoomId = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "room");
+			if (!pJsonRspRoomId) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Missing response (plugindata.data.room)\n");
+				goto end_dispatch;
+			}
+			if (cJSON_IsNumber(pJsonRspRoomId)) {
+				roomId = (janus_id_t) pJsonRspRoomId->valuedouble;
+			} else if (cJSON_IsString(pJsonRspRoomId)) {
+				roomId = 0;
+			} else {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (plugindata.data.room)\n");
+				goto end_dispatch;
+			}
+			MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "roomId=%" SWITCH_UINT64_T_FMT "\n", (janus_id_t) roomId);
+
+			pJsonRspParticipantId = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "id");
+			if (pJsonRspParticipantId) {
+				if (cJSON_IsNumber(pJsonRspParticipantId)) {
+					participantId = (janus_id_t) pJsonRspParticipantId->valuedouble;
+					MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "participantId=%" SWITCH_UINT64_T_FMT "\n", (janus_id_t) participantId);
+				} else if (cJSON_IsString(pJsonRspParticipantId)) {
+					participantId = 0;
+				} else {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (plugindata.data.id)\n");
+					goto end_dispatch;
+				}
+				if ((*pJoinedFunc)(pResponse->serverId, pResponse->senderId, roomId, participantId)) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't join\n");
+				}
+			} else {
+				MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Someone else has joined\n");
+			}
+		} else if (!strcmp("event", pJsonRspType->valuestring)) {
+			pJsonRspType = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "result");
+			if (pJsonRspType) {
+				if (!cJSON_IsString(pJsonRspType) || strcmp("ok", pJsonRspType->valuestring)) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (plugindata.data.result)\n");
+					goto end_dispatch;
+				}
+
+				pJsonRspJsepType = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonJsep, "type");
+				if (!cJSON_IsString(pJsonRspJsepType) || strcmp("answer", pJsonRspJsepType->valuestring)) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (jsep.type)\n");
+					goto end_dispatch;
+				}
+
+				pJsonRspJsepSdp = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonJsep, "sdp");
+				if (!cJSON_IsString(pJsonRspJsepSdp)) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (jsep.sdp)\n");
+					goto end_dispatch;
+				}
+
+				if ((*pAcceptedFunc)(pResponse->serverId, pResponse->senderId, pJsonRspJsepSdp->valuestring)) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't accept\n");
+				}
+
+				if (!pAnswerOnWebrtcupFunc || !pAnswerOnWebrtcupFunc(pResponse->serverId, pResponse->senderId)) {
+					if ((*pAnsweredFunc)(pResponse->serverId, pResponse->senderId)) {
+						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't answer\n");
+					}
+				}
+			} else if ((pJsonRspType = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "leaving")) != NULL) {
+				if (cJSON_IsNumber(pJsonRspType)) {
+					MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "leaving=%" SWITCH_UINT64_T_FMT "\n", (janus_id_t) pJsonRspType->valuedouble);
+				} else if (cJSON_IsString(pJsonRspType)) {
+					MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "leaving=%s (string id)\n", pJsonRspType->valuestring);
+				} else {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (plugindata.data.leaving)\n");
+					goto end_dispatch;
+				}
+			} else if ((pJsonRspErrorCode = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "error_code")) != NULL
+						&& (pJsonRspError = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "error")) != NULL) {
+				if (!cJSON_IsNumber(pJsonRspErrorCode) || !cJSON_IsString(pJsonRspError)) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "No error code or reason on join request\n");
+					goto end_dispatch;
+				}
+				MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "error_code=%d\n", pJsonRspErrorCode->valueint);
+				MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "error=%s\n", pJsonRspError->valuestring);
+
+				if ((*pHungupFunc)(pResponse->serverId, pResponse->senderId, pJsonRspError->valuestring)) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't hangup\n");
+				}
+			} else {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Unknown audiobridge event\n");
+				goto end_dispatch;
+			}
+		} else if (!strcmp("left", pJsonRspType->valuestring)) {
+			MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Caller has left the room\n");
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Unknown result - audiobridge=%s\n", pJsonRspType->valuestring);
+		}
+	} else {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Unknown event - janus=%s\n", pResponse->pType);
+	}
+
+end_dispatch:
+	switch_safe_free(pResponse);
+	return SWITCH_STATUS_SUCCESS;
+}
+
+janus_id_t apiGetServerId(server_t *pServer) {
   	janus_id_t serverId = 0;
 	message_t request, *pResponse = NULL;
 
   	cJSON *pJsonRequest = NULL;
  	cJSON *pJsonResponse = NULL;
-	cJSON *pJsonRspId;
+  	cJSON *pJsonRspId;
   	char *pTransactionId = generateTransactionId();
 
-	switch_assert(pUrl);
+	switch_assert(pServer);
+	switch_assert(pServer->pUrl);
 
   	//"{\"janus\":\"create\",\"transaction\":\"5Y1VuEbeNf7U\",\"apisecret\":\"API-SECRET\"}";
 
 	(void) memset((void *) &request, 0, sizeof(request));
 	request.pType = "create";
 	request.pTransactionId = pTransactionId;
-	request.pSecret = pSecret;
-	request.pHmacSecret = pHmacSecret;
+	request.pSecret = pServer->pSecret;
+	request.pHmacSecret = pServer->pHmacSecret;
 
 	if (!(pJsonRequest = encode(request))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Cannot create request\n");
 		goto done;
 	}
 
-	DEBUG(SWITCH_CHANNEL_LOG, "Sending HTTP request\n");
-	pJsonResponse = httpPost(pUrl, HTTP_POST_TIMEOUT, pJsonRequest);
+	pJsonResponse = api_send_request(pServer, pJsonRequest, pTransactionId, 0, 0, URL_ROOT, "create");
 
 	if (!(pResponse = decode(pJsonResponse))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response\n");
@@ -366,7 +622,7 @@ janus_id_t apiGetServerId(const char *pUrl, const char *pSecret, const char *pHm
   	return serverId;
 }
 
-switch_status_t apiClaimServerId(const char *pUrl, const char *pSecret, const char *pHmacSecret, janus_id_t serverId) {
+switch_status_t apiClaimServerId(server_t *pServer, janus_id_t serverId) {
 	message_t request, *pResponse = NULL;
 	switch_status_t result = SWITCH_STATUS_SUCCESS;
 
@@ -376,17 +632,17 @@ switch_status_t apiClaimServerId(const char *pUrl, const char *pSecret, const ch
 	cJSON *pJsonRspErrorCode;
 	cJSON *pJsonRspErrorReason;
 	char *pTransactionId = generateTransactionId();
-	char url[1024];
 
-	switch_assert(pUrl);
+	switch_assert(pServer);
+	switch_assert(pServer->pUrl);
 
   	//"{\"janus\":\"claim\",\"transaction\":\"5Y1VuEbeNf7U\",\"apisecret\":\"API-SECRET\",\"session_id\":999999}";
 
 	(void) memset((void *) &request, 0, sizeof(request));
 	request.pType = "claim";
 	request.pTransactionId = pTransactionId;
-	request.pSecret = pSecret;
-	request.pHmacSecret = pHmacSecret;
+	request.pSecret = pServer->pSecret;
+	request.pHmacSecret = pServer->pHmacSecret;
 
 	if (!(pJsonRequest = encode(request))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Cannot create request\n");
@@ -394,14 +650,7 @@ switch_status_t apiClaimServerId(const char *pUrl, const char *pSecret, const ch
 		goto done;
 	}
 
-	if (snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT, pUrl, serverId) < 0) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Could not generate URL\n");
-			result = SWITCH_STATUS_FALSE;
-		goto done;
-	}
-
-	DEBUG(SWITCH_CHANNEL_LOG, "Sending HTTP request\n");
-    pJsonResponse = httpPost(url, HTTP_POST_TIMEOUT, pJsonRequest);
+	pJsonResponse = api_send_request(pServer, pJsonRequest, pTransactionId, serverId, 0, URL_SESSION, "claim");
 
 	if (!(pResponse = decode(pJsonResponse))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response\n");
@@ -416,7 +665,7 @@ switch_status_t apiClaimServerId(const char *pUrl, const char *pSecret, const ch
 	}
 
 	if (!strcmp(pResponse->pType, "success")) {
-		DEBUG(SWITCH_CHANNEL_LOG, "Successful claim\n");
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Successful claim\n");
 		result = SWITCH_STATUS_SUCCESS;
 		goto done;
 	} else if (!strcmp(pResponse->pType, "error")) {
@@ -428,7 +677,7 @@ switch_status_t apiClaimServerId(const char *pUrl, const char *pSecret, const ch
 				result = SWITCH_STATUS_FALSE;
 				goto done;
 			}
-			DEBUG(SWITCH_CHANNEL_LOG, "error.code=%d\n", pJsonRspErrorCode->valueint);
+			MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "error.code=%d\n", pJsonRspErrorCode->valueint);
 
 			pJsonRspErrorReason = cJSON_GetObjectItemCaseSensitive(pJsonRspError, "reason");
 			if (!cJSON_IsString(pJsonRspErrorReason)) {
@@ -436,7 +685,7 @@ switch_status_t apiClaimServerId(const char *pUrl, const char *pSecret, const ch
 				result = SWITCH_STATUS_FALSE;
 				goto done;
 			}
-			DEBUG(SWITCH_CHANNEL_LOG, "error.reason=%s\n", pJsonRspErrorReason->valuestring);
+			MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "error.reason=%s\n", pJsonRspErrorReason->valuestring);
 			result = SWITCH_STATUS_NOT_INITALIZED;
 			goto done;
 		} else {
@@ -459,7 +708,7 @@ switch_status_t apiClaimServerId(const char *pUrl, const char *pSecret, const ch
   	return result;
 }
 
-janus_id_t apiGetSenderId(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId, const char *callId) {
+janus_id_t apiGetSenderId(server_t *pServer, const janus_id_t serverId, const char *callId) {
 	message_t request, *pResponse = NULL;
 	janus_id_t senderId = 0;
 
@@ -467,22 +716,19 @@ janus_id_t apiGetSenderId(const char *pUrl, const char *pSecret, const char *pHm
 	cJSON *pJsonResponse = NULL;
 	cJSON *pJsonRspId;
 	char *pTransactionId = generateTransactionId();
-	char url[1024];
 
-	switch_assert(pUrl);
+	switch_assert(pServer);
+	switch_assert(pServer->pUrl);
 
 	// {"janus":"attach","plugin":"janus.plugin.audiobridge","opaque_id":"audiobridgetest-QsFKsttqnbOx","transaction":"ScRdYl6r0qoX"}
-
-	// If opaque_id is present in the message (attach request), add it, since we use call_id to correlate Janus events to the call
-	// https://github.com/meetecho/janus-gateway/pull/748
 
 	(void) memset((void *) &request, 0, sizeof(request));
 	request.pType = "attach";
 	request.serverId = serverId;
 	request.pTransactionId = pTransactionId;
 	request.opaqueId = callId;
-	request.pSecret = pSecret;
-	request.pHmacSecret = pHmacSecret;
+	request.pSecret = pServer->pSecret;
+	request.pHmacSecret = pServer->pHmacSecret;
 	request.isPlugin = SWITCH_TRUE;
 
 	if (!(pJsonRequest = encode(request))) {
@@ -490,14 +736,7 @@ janus_id_t apiGetSenderId(const char *pUrl, const char *pSecret, const char *pHm
 		goto done;
 	}
 
-	if (snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT, pUrl, serverId) < 0) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Could not generate URL\n");
-		goto done;
-	}
-
-	DEBUG(SWITCH_CHANNEL_LOG, "Sending HTTP request\n");
-	//	http_get("https://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html", session);
-	pJsonResponse = httpPost(url, HTTP_POST_TIMEOUT, pJsonRequest);
+	pJsonResponse = api_send_request(pServer, pJsonRequest, pTransactionId, serverId, 0, URL_SESSION, "attach");
 
 	if (!(pResponse = decode(pJsonResponse))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response\n");
@@ -526,7 +765,7 @@ janus_id_t apiGetSenderId(const char *pUrl, const char *pSecret, const char *pHm
 	return senderId;
 }
 
-janus_id_t apiCreateRoom(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId,
+janus_id_t apiCreateRoom(server_t *pServer, const janus_id_t serverId,
 		const janus_id_t senderId, const janus_id_t roomId, const char *pDescription,
 		switch_bool_t record, const char *pRecordingFile, const char *pPin, const char *pRoomIdStr) {
 	message_t request, *pResponse = NULL;
@@ -538,9 +777,9 @@ janus_id_t apiCreateRoom(const char *pUrl, const char *pSecret, const char *pHma
 	cJSON *pJsonRspErrorCode;
 	cJSON *pJsonRspRoomId;
 	char *pTransactionId = generateTransactionId();
-	char url[1024];
 
-	switch_assert(pUrl);
+	switch_assert(pServer);
+	switch_assert(pServer->pUrl);
 
 	//"{\"janus\":\"message\",\"transaction\":\"%s\",\"apisecret\":\"%s\",\"body\":{\"request\":\"create\",\"room\":%s}}",
 
@@ -548,8 +787,8 @@ janus_id_t apiCreateRoom(const char *pUrl, const char *pSecret, const char *pHma
 	request.pType = "message";
 	request.serverId = serverId;
 	request.pTransactionId = pTransactionId;
-	request.pSecret = pSecret;
-	request.pHmacSecret = pHmacSecret;
+	request.pSecret = pServer->pSecret;
+	request.pHmacSecret = pServer->pHmacSecret;
 
 	request.pJsonBody = cJSON_CreateObject();
 	if (request.pJsonBody == NULL) {
@@ -605,14 +844,7 @@ janus_id_t apiCreateRoom(const char *pUrl, const char *pSecret, const char *pHma
 		goto done;
 	}
 
-	if (snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT "/%" SWITCH_UINT64_T_FMT, pUrl, serverId, senderId) < 0) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Could not generate URL\n");
-		goto done;
-	}
-
-	DEBUG(SWITCH_CHANNEL_LOG, "Sending HTTP request\n");
-	//	http_get("https://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html", session);
-	pJsonResponse = httpPost(url, HTTP_POST_TIMEOUT, pJsonRequest);
+	pJsonResponse = api_send_request(pServer, pJsonRequest, pTransactionId, serverId, senderId, URL_HANDLE, "create room");
 
 	if (!(pResponse = decode(pJsonResponse))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response\n");
@@ -640,8 +872,7 @@ janus_id_t apiCreateRoom(const char *pUrl, const char *pSecret, const char *pHma
 		}
 
 		if (pJsonRspErrorCode->valueint == 486) {
-			// its not a proper error if the room already exists
-			DEBUG(SWITCH_CHANNEL_LOG, "Room already exists\n");
+			MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Room already exists\n");
 			result = (pRoomIdStr && *pRoomIdStr) ? 1 : (roomId != 0 ? roomId : 1); /* never 0: caller uses !apiCreateRoom() */
 		} else {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (error_code) - error=%d\n", pJsonRspErrorCode->valueint);
@@ -655,10 +886,10 @@ janus_id_t apiCreateRoom(const char *pUrl, const char *pSecret, const char *pHma
 	  }
 	  if (cJSON_IsNumber(pJsonRspRoomId)) {
 	    result = (janus_id_t) pJsonRspRoomId->valuedouble;
-		DEBUG(SWITCH_CHANNEL_LOG, "Create room success (integer room)\n");
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Create room success (integer room)\n");
 	  } else if (cJSON_IsString(pJsonRspRoomId)) {
 	    result = 1; /* string room: success; caller uses (apiCreateRoom() == 0) so must be non-zero */
-	    DEBUG(SWITCH_CHANNEL_LOG, "Create room success (string room)\n");
+	    MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Create room success (string room)\n");
 	  } else {
 	    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (plugindata.data.room)\n");
 	    goto done;
@@ -677,7 +908,7 @@ janus_id_t apiCreateRoom(const char *pUrl, const char *pSecret, const char *pHma
 	return result;
 }
 
-switch_status_t apiJoin(const char *pUrl, const char *pSecret, const char *pHmacSecret, int hmacTokenTtl,
+switch_status_t apiJoin(server_t *pServer, int hmacTokenTtl,
 		const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId,
 		const char *pDisplay, const char *pPin, const char *pToken, const char *callId, const char *pRoomIdStr) {
 	message_t request, *pResponse = NULL;
@@ -688,9 +919,9 @@ switch_status_t apiJoin(const char *pUrl, const char *pSecret, const char *pHmac
 	char *pTransactionId = generateTransactionId();
 	char *pSignedToken = NULL; /* owned here, freed in "done:" */
 	char roomDesc[96];
-  	char url[1024];
 
-	switch_assert(pUrl);
+	switch_assert(pServer);
+	switch_assert(pServer->pUrl);
 
   //"{\"janus\":\"message\",\"transaction\":\"%s\",\"apisecret\":\"%s\",\"body\":{\"request\":\"join\",\"room\":%lu,\"display\":\"%s\"}}",
 
@@ -698,8 +929,8 @@ switch_status_t apiJoin(const char *pUrl, const char *pSecret, const char *pHmac
 	request.pType = "message";
 	request.serverId = serverId;
 	request.pTransactionId = pTransactionId;
-	request.pSecret = pSecret;
-	request.pHmacSecret = pHmacSecret;
+	request.pSecret = pServer->pSecret;
+	request.pHmacSecret = pServer->pHmacSecret;
 	request.hmacTokenTtl = hmacTokenTtl > 0 ? hmacTokenTtl : API_HMAC_DEFAULT_CALL_TTL;
 
 	/*
@@ -711,7 +942,7 @@ switch_status_t apiJoin(const char *pUrl, const char *pSecret, const char *pHmac
 	 * it. The inbound `pToken` (stored-mode token from the
 	 * `janus-user-token` channel variable) is ignored in signed mode.
 	 */
-	if (pHmacSecret) {
+	if (pServer->pHmacSecret) {
 		if (pRoomIdStr && *pRoomIdStr) {
 			(void) switch_snprintf(roomDesc, sizeof(roomDesc), "room=%s", pRoomIdStr);
 		} else {
@@ -807,14 +1038,7 @@ switch_status_t apiJoin(const char *pUrl, const char *pSecret, const char *pHmac
 		}
 	}
 
-	if (snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT "/%" SWITCH_UINT64_T_FMT, pUrl, serverId, senderId) < 0) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Could not generate URL\n");
-		result = SWITCH_STATUS_FALSE;
-		goto done;
-	}
-
-	DEBUG(SWITCH_CHANNEL_LOG, "Sending HTTP request\n");
-  	pJsonResponse = httpPost(url, HTTP_POST_TIMEOUT, pJsonRequest);
+	pJsonResponse = api_send_request(pServer, pJsonRequest, pTransactionId, serverId, senderId, URL_HANDLE, "join");
 
 	if (!(pResponse = decode(pJsonResponse))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response\n");
@@ -839,7 +1063,7 @@ switch_status_t apiJoin(const char *pUrl, const char *pSecret, const char *pHmac
   	return result;
 }
 
-switch_status_t apiConfigure(const char *pUrl, const char *pSecret, const char *pHmacSecret,
+switch_status_t apiConfigure(server_t *pServer,
 		const janus_id_t serverId, const janus_id_t senderId, const switch_bool_t muted,
 		switch_bool_t record, const char *pRecordingFile,
 		const char *pType, const char *pSdp, const char *callId) {
@@ -849,9 +1073,9 @@ switch_status_t apiConfigure(const char *pUrl, const char *pSecret, const char *
   	cJSON *pJsonRequest = NULL;
 	cJSON *pJsonResponse = NULL;
 	char *pTransactionId = generateTransactionId();
-  	char url[1024];
 
-	switch_assert(pUrl);
+	switch_assert(pServer);
+	switch_assert(pServer->pUrl);
 
 	//{"janus":"message","body":{"request":"configure","muted":false},"transaction":"QPDt2vYOQmmd","jsep":{"type":"offer","sdp":"..."}}
 
@@ -859,8 +1083,8 @@ switch_status_t apiConfigure(const char *pUrl, const char *pSecret, const char *
 	request.pType = "message";
 	request.serverId = serverId;
 	request.pTransactionId = pTransactionId;
-	request.pSecret = pSecret;
-	request.pHmacSecret = pHmacSecret;
+	request.pSecret = pServer->pSecret;
+	request.pHmacSecret = pServer->pHmacSecret;
 
 	request.pJsonBody = cJSON_CreateObject();
 
@@ -937,14 +1161,7 @@ switch_status_t apiConfigure(const char *pUrl, const char *pSecret, const char *
     	goto done;
   	}
 
-	if (snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT "/%" SWITCH_UINT64_T_FMT, pUrl, serverId, senderId) < 0) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Could not generate URL\n");
-		result = SWITCH_STATUS_FALSE;
-		goto done;
-	}
-
-	DEBUG(SWITCH_CHANNEL_LOG, "Sending HTTP request\n");
-  	pJsonResponse = httpPost(url, HTTP_POST_TIMEOUT, pJsonRequest);
+	pJsonResponse = api_send_request(pServer, pJsonRequest, pTransactionId, serverId, senderId, URL_HANDLE, "configure");
 
 	if (!(pResponse = decode(pJsonResponse))) {
     	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response\n");
@@ -968,16 +1185,16 @@ switch_status_t apiConfigure(const char *pUrl, const char *pSecret, const char *
   	return result;
 }
 
-switch_status_t apiLeave(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId, const janus_id_t senderId, const char *callId) {
+switch_status_t apiLeave(server_t *pServer, const janus_id_t serverId, const janus_id_t senderId, const char *callId) {
 	message_t request, *pResponse = NULL;
 	switch_status_t result = SWITCH_STATUS_SUCCESS;
 
   	cJSON *pJsonRequest = NULL;
 	cJSON *pJsonResponse = NULL;
 	char *pTransactionId = generateTransactionId();
-  	char url[1024];
 
-	switch_assert(pUrl);
+	switch_assert(pServer);
+	switch_assert(pServer->pUrl);
 
 	//{"janus":"message","body":{"request":"leave"},"transaction":"QPDt2vYOQmmd"}
 
@@ -985,8 +1202,8 @@ switch_status_t apiLeave(const char *pUrl, const char *pSecret, const char *pHma
 	request.pType = "message";
 	request.serverId = serverId;
 	request.pTransactionId = pTransactionId;
-	request.pSecret = pSecret;
-	request.pHmacSecret = pHmacSecret;
+	request.pSecret = pServer->pSecret;
+	request.pHmacSecret = pServer->pHmacSecret;
 
 	request.pJsonBody = cJSON_CreateObject();
 	if (request.pJsonBody == NULL) {
@@ -1014,14 +1231,7 @@ switch_status_t apiLeave(const char *pUrl, const char *pSecret, const char *pHma
 		goto done;
 	}
 
-	if (snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT "/%" SWITCH_UINT64_T_FMT, pUrl, serverId, senderId) < 0) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Could not generate URL\n");
-		result = SWITCH_STATUS_FALSE;
-		goto done;
-	}
-
-	DEBUG(SWITCH_CHANNEL_LOG, "Sending HTTP request\n");
-  	pJsonResponse = httpPost(url, HTTP_POST_TIMEOUT, pJsonRequest);
+	pJsonResponse = api_send_request(pServer, pJsonRequest, pTransactionId, serverId, senderId, URL_HANDLE, "leave");
 
 	if (!(pResponse = decode(pJsonResponse))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response\n");
@@ -1045,23 +1255,23 @@ switch_status_t apiLeave(const char *pUrl, const char *pSecret, const char *pHma
 	return result;
 }
 
-switch_status_t apiDetach(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId, const janus_id_t senderId) {
+switch_status_t apiDetach(server_t *pServer, const janus_id_t serverId, const janus_id_t senderId) {
 	message_t request, *pResponse = NULL;
 	switch_status_t result = SWITCH_STATUS_SUCCESS;
 
   	cJSON *pJsonRequest = NULL;
 	cJSON *pJsonResponse = NULL;
 	char *pTransactionId = generateTransactionId();
-  	char url[1024];
 
-	switch_assert(pUrl);
+	switch_assert(pServer);
+	switch_assert(pServer->pUrl);
 
 	(void) memset((void *) &request, 0, sizeof(request));
 	request.pType = "detach";
-	request.pHmacSecret = pHmacSecret;
 	request.serverId = serverId;
 	request.pTransactionId = pTransactionId;
-	request.pSecret = pSecret;
+	request.pSecret = pServer->pSecret;
+	request.pHmacSecret = pServer->pHmacSecret;
 
 	if (!(pJsonRequest = encode(request))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Cannot create request\n");
@@ -1069,14 +1279,7 @@ switch_status_t apiDetach(const char *pUrl, const char *pSecret, const char *pHm
 		goto done;
 	}
 
-	if (snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT "/%" SWITCH_UINT64_T_FMT, pUrl, serverId, senderId) < 0) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Could not generate URL\n");
-		result = SWITCH_STATUS_FALSE;
-		goto done;
-	}
-	
-	DEBUG(SWITCH_CHANNEL_LOG, "Sending HTTP request\n");
-  	pJsonResponse = httpPost(url, HTTP_POST_TIMEOUT, pJsonRequest);
+	pJsonResponse = api_send_request(pServer, pJsonRequest, pTransactionId, serverId, senderId, URL_HANDLE, "detach");
 
 	if (!(pResponse = decode(pJsonResponse))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response\n");
@@ -1099,43 +1302,48 @@ switch_status_t apiDetach(const char *pUrl, const char *pSecret, const char *pHm
   	return result;
 }
 
-switch_status_t apiPoll(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId, const char *pAuthToken,
-  	switch_status_t (*pJoinedFunc)(const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const janus_id_t participantId),
-  	switch_status_t (*pAcceptedFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pSdp),
+switch_status_t apiPoll(server_t *pServer, const janus_id_t serverId,
+	switch_status_t (*pJoinedFunc)(const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const janus_id_t participantId),
+	switch_status_t (*pAcceptedFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pSdp),
 	switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
 	switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
-  	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
-  	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason)) {
+	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
+	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason))
+{
 	switch_status_t result = SWITCH_STATUS_SUCCESS;
 
-  	cJSON *pJsonResponse = NULL;
+	cJSON *pJsonResponse = NULL;
 	cJSON *pEvent;
-	cJSON *pJsonRspReason;
-	cJSON *pJsonRspType;
-	cJSON *pJsonRspRoomId;
-	cJSON *pJsonRspParticipantId;
-	cJSON *pJsonRspJsepType;
-	cJSON *pJsonRspJsepSdp;
-	cJSON *pJsonRspError;
-	cJSON *pJsonRspErrorCode;
 
 	char *pSignedToken = NULL;
-  	char url[1024];
+	const char *pAuthToken;
+	char url[1024];
 
-	switch_assert(pUrl);
+	switch_assert(pServer);
+	switch_assert(pServer->pUrl);
 
-	if (snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT "?maxev=%d", pUrl, serverId, MAX_POLL_EVENTS) < 0) {
+#if defined(HAVE_MOD_JANUS_WS)
+	if (pServer->transport == JANUS_TP_WS) {
+		return janus_ws_pump_once(pServer, serverId,
+			(switch_interval_time_t)HTTP_GET_TIMEOUT * 1000,
+			(switch_interval_time_t)(25 * 1000000),
+			&pServer->ws_last_poll,
+			pJoinedFunc, pAcceptedFunc, pTrickleFunc, pAnswerOnWebrtcupFunc, pAnsweredFunc, pHungupFunc);
+	}
+#endif
+
+	if (snprintf(url, sizeof(url), "%s/%" SWITCH_UINT64_T_FMT "?maxev=%d", pServer->pUrl, serverId, MAX_POLL_EVENTS) < 0) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Could not generate URL\n");
 		result = SWITCH_STATUS_FALSE;
 		goto done;
 	}
 
-	if (pSecret) {
+	if (pServer->pSecret) {
 		size_t len = strlen(url);
-		if (snprintf(&url[len], sizeof(url) - len, "&apisecret=%s", pSecret) < 0) {
+		if (snprintf(&url[len], sizeof(url) - len, "&apisecret=%s", pServer->pSecret) < 0) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Could not generate secret\n");
 			result = SWITCH_STATUS_FALSE;
-	    	goto done;
+			goto done;
 		}
 	}
 
@@ -1145,9 +1353,10 @@ switch_status_t apiPoll(const char *pUrl, const char *pSecret, const char *pHmac
 	 * lifecycle TTL is short on purpose — we regenerate per poll cycle, so
 	 * leaking a URL to logs only exposes a 5-minute window.
 	 */
-	if (pHmacSecret) {
+	pAuthToken = pServer->pAuthToken;
+	if (pServer->pHmacSecret) {
 		const char *pDescriptors[1] = { JANUS_PLUGIN };
-		pSignedToken = authSignToken(pHmacSecret, API_HMAC_DEFAULT_LIFECYCLE_TTL, pDescriptors, 1);
+		pSignedToken = authSignToken(pServer->pHmacSecret, API_HMAC_DEFAULT_LIFECYCLE_TTL, pDescriptors, 1);
 		if (!pSignedToken) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Cannot sign poll token\n");
 			result = SWITCH_STATUS_FALSE;
@@ -1165,8 +1374,7 @@ switch_status_t apiPoll(const char *pUrl, const char *pSecret, const char *pHmac
 		}
 	}
 
-	DEBUG(SWITCH_CHANNEL_LOG, "Sending HTTP request - url=%s\n", url);
-	//	http_get("https://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html", session);
+	MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Sending HTTP request - url=%s\n", url);
 	pJsonResponse = httpGet(url, HTTP_GET_TIMEOUT);
 
 	if (pJsonResponse == NULL) {
@@ -1176,168 +1384,17 @@ switch_status_t apiPoll(const char *pUrl, const char *pSecret, const char *pHmac
 	}
 
 	pEvent = pJsonResponse ? pJsonResponse->child : NULL;
-  	while (pEvent) {
-		message_t *pResponse = NULL;
+	while (pEvent) {
+		cJSON *next = pEvent->next;
+		(void) api_dispatch_poll_event(pEvent, pJoinedFunc, pAcceptedFunc, pTrickleFunc, pAnswerOnWebrtcupFunc, pAnsweredFunc, pHungupFunc);
+		pEvent = next;
+	}
 
-		if (!(pResponse = decode(pEvent))) {
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response\n");
-			goto endloop;
-		}
-
-		if (!strcmp(pResponse->pType, "keepalive")) {
-			DEBUG(SWITCH_CHANNEL_LOG, "Its a keepalive - do nothing\n");
-		} else if (!strcmp(pResponse->pType, "hangup")) {
-			DEBUG(SWITCH_CHANNEL_LOG, "Its an hangup\n");
-
-			pJsonRspReason = cJSON_GetObjectItemCaseSensitive(pEvent, "reason");
-			if (!cJSON_IsString(pJsonRspReason)) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (reason)\n");
-				goto endloop;
-			}
-
-			if ((*pHungupFunc)(pResponse->serverId, pResponse->senderId, pJsonRspReason->valuestring)) {
-			 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't hangup\n");
-			}
-		} else if (!strcmp(pResponse->pType, "detached")) {
-			// treat detached the same as hangup in case we missed the first message -
-			// this might mean we call the hungup function when the call has been terminated
-			if ((*pHungupFunc)(pResponse->serverId, pResponse->senderId, NULL)) {
-			 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't detach\n");
-			}
-		} else if (!strcmp(pResponse->pType, "webrtcup")) {
-			DEBUG(SWITCH_CHANNEL_LOG, "WebRTC has been setup\n");
-			/* Answer on webrtcup only when channel has answer_on_webrtcup set */
-			if (pAnswerOnWebrtcupFunc && pAnswerOnWebrtcupFunc(pResponse->serverId, pResponse->senderId)) {
-				if ((*pAnsweredFunc)(pResponse->serverId, pResponse->senderId)) {
-					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't answer (on webrtcup)\n");
-				}
-			}
-		} else if (!strcmp(pResponse->pType, "media")) {
-			DEBUG(SWITCH_CHANNEL_LOG, "Media is flowing\n");
-		} else if (!strcmp(pResponse->pType, "trickle")) {
-			DEBUG(SWITCH_CHANNEL_LOG, "Receieved a candidate\n");
-
-			if ((*pTrickleFunc)(pResponse->serverId, pResponse->senderId, pResponse->pCandidate)) {
-			 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't add candidate\n");
-			}
-		} else if (!strcmp(pResponse->pType, "event")) {
-			pJsonRspType = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "audiobridge");
-			if (!cJSON_IsString(pJsonRspType)) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "No response (plugindata.data.audiobridge)\n");
-				goto endloop;
-			}
-
-			if (!strcmp("joined", pJsonRspType->valuestring)) {
-				janus_id_t roomId;
-				janus_id_t participantId;
-
-				pJsonRspRoomId = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "room");
-				if (!pJsonRspRoomId) {
-					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Missing response (plugindata.data.room)\n");
-					goto endloop;
-				}
-				if (cJSON_IsNumber(pJsonRspRoomId)) {
-					roomId = (janus_id_t) pJsonRspRoomId->valuedouble;
-				} else if (cJSON_IsString(pJsonRspRoomId)) {
-					roomId = 0; /* string room (e.g. UUID); callback does not use roomId for string rooms */
-				} else {
-					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (plugindata.data.room)\n");
-					goto endloop;
-				}
-				DEBUG(SWITCH_CHANNEL_LOG, "roomId=%" SWITCH_UINT64_T_FMT "\n", (janus_id_t) roomId);
-
-				pJsonRspParticipantId = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "id");
-				if (pJsonRspParticipantId) {
-					if (cJSON_IsNumber(pJsonRspParticipantId)) {
-						participantId = (janus_id_t) pJsonRspParticipantId->valuedouble;
-						DEBUG(SWITCH_CHANNEL_LOG, "participantId=%" SWITCH_UINT64_T_FMT "\n", (janus_id_t) participantId);
-					} else if (cJSON_IsString(pJsonRspParticipantId)) {
-						participantId = 0; /* string participant id (e.g. UUID); callback does not use it for string ids */
-					} else {
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (plugindata.data.id)\n");
-						goto endloop;
-					}
-					// call the relevant handler in mod_janus
-					if ((*pJoinedFunc)(pResponse->serverId, pResponse->senderId, roomId, participantId)) {
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't join\n");
-					}
-				} else {
-					DEBUG(SWITCH_CHANNEL_LOG, "Someone else has joined\n");
-				}
-			} else if (!strcmp("event", pJsonRspType->valuestring)) {
-				pJsonRspType = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "result");
-				if (pJsonRspType) {
-					if (!cJSON_IsString(pJsonRspType) || strcmp("ok", pJsonRspType->valuestring)) {
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (plugindata.data.result)\n");
-						goto endloop;
-					}
-
-					pJsonRspJsepType = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonJsep, "type");
-					if (!cJSON_IsString(pJsonRspJsepType) || strcmp("answer", pJsonRspJsepType->valuestring)) {
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (jsep.type)\n");
-						goto endloop;
-					}
-
-					pJsonRspJsepSdp = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonJsep, "sdp");
-					if (!cJSON_IsString(pJsonRspJsepSdp)) {
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (jsep.sdp)\n");
-						goto endloop;
-					}
-
-					if ((*pAcceptedFunc)(pResponse->serverId, pResponse->senderId, pJsonRspJsepSdp->valuestring)) {
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't accept\n");
-					}
-
-					/* Answer on jsep unless channel has answer_on_webrtcup set */
-					if (!pAnswerOnWebrtcupFunc || !pAnswerOnWebrtcupFunc(pResponse->serverId, pResponse->senderId)) {
-						if ((*pAnsweredFunc)(pResponse->serverId, pResponse->senderId)) {
-							switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't answer\n");
-						}
-					}
-				} else if ((pJsonRspType = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "leaving")) != NULL) {
-					if (cJSON_IsNumber(pJsonRspType)) {
-						DEBUG(SWITCH_CHANNEL_LOG, "leaving=%" SWITCH_UINT64_T_FMT "\n", (janus_id_t) pJsonRspType->valuedouble);
-					} else if (cJSON_IsString(pJsonRspType)) {
-						DEBUG(SWITCH_CHANNEL_LOG, "leaving=%s (string id)\n", pJsonRspType->valuestring);
-					} else {
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid response (plugindata.data.leaving)\n");
-						goto endloop;
-					}
-				} else if ((pJsonRspErrorCode = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "error_code")) != NULL
-							&& (pJsonRspError = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "error")) != NULL) {
-					if (!cJSON_IsNumber(pJsonRspErrorCode) || !cJSON_IsString(pJsonRspError)) {
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "No error code or reason on join request\n");
-						goto endloop;
-					}
-					DEBUG(SWITCH_CHANNEL_LOG, "error_code=%d\n", pJsonRspErrorCode->valueint);
-					DEBUG(SWITCH_CHANNEL_LOG, "error=%s\n", pJsonRspError->valuestring);
-
-					if ((*pHungupFunc)(pResponse->serverId, pResponse->senderId, pJsonRspError->valuestring)) {
-			 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't hangup\n");
-					}
-				} else {
-					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Unknown audiobridge event\n");
-					goto endloop;
-				}
-			} else if (!strcmp("left", pJsonRspType->valuestring)) {
-				DEBUG(SWITCH_CHANNEL_LOG, "Caller has left the room\n");
-			} else {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Unknown result - audiobridge=%s\n", pJsonRspType->valuestring);
-			}
-		} else {
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Unknown event - janus=%s\n", pResponse->pType);
-		}
-
-		endloop:
-		switch_safe_free(pResponse);
-     	pEvent = pEvent->next;
-  	}
-
-	done:
+done:
 	cJSON_Delete(pJsonResponse);
 	switch_safe_free(pSignedToken);
 
-  return result;
+	return result;
 }
 /* For Emacs:
  * Local Variables:

--- a/api.h
+++ b/api.h
@@ -34,6 +34,8 @@
 #define	_API_H_
 
 #include  "globals.h"
+#include  "servers.h"
+#include  "cJSON.h"
 
 /*
  * Default TTLs (seconds) used for internally generated HMAC-signed tokens
@@ -46,24 +48,37 @@
 #define API_HMAC_DEFAULT_CALL_TTL     7200 /* 2 hours */
 #define API_HMAC_DEFAULT_LIFECYCLE_TTL 300 /* 5 minutes */
 
-janus_id_t apiGetServerId(const char *pUrl, const char *pSecret, const char *pHmacSecret);
-switch_status_t apiClaimServerId(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId);
-janus_id_t apiGetSenderId(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId, const char *callId);
-janus_id_t apiCreateRoom(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const char *pDescription, switch_bool_t record, const char *pRecordingFile, const char *pPin, const char *pRoomIdStr);
-switch_status_t apiJoin(const char *pUrl, const char *pSecret, const char *pHmacSecret, int hmacTokenTtl, const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const char *pDisplay, const char *pPin, const char *pToken, const char *callId, const char *pRoomIdStr);
-switch_status_t apiConfigure(const char *pUrl, const char *pSecret, const char *pHmacSecret,
-		const janus_id_t serverId, const janus_id_t senderId, const switch_bool_t muted,
-		switch_bool_t record, const char *pRecordingFile,
-		const char *pType, const char *pSdp, const char *callId);
-switch_status_t apiLeave(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId, const janus_id_t senderId, const char *callId);
-switch_status_t apiDetach(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId, const janus_id_t senderId);
-switch_status_t apiPoll(const char *pUrl, const char *pSecret, const char *pHmacSecret, const janus_id_t serverId, const char *pAuthToken,
-switch_status_t (*pJoinedFunc)(const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const janus_id_t participantId),
-switch_status_t (*pAcceptedFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pSdp),
-switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
-switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
-switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
-switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason));
+/* Dispatch one Janus event object (HTTP long-poll element or WebSocket text frame). */
+switch_status_t api_dispatch_poll_event(cJSON *pEvent,
+	switch_status_t (*pJoinedFunc)(const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const janus_id_t participantId),
+	switch_status_t (*pAcceptedFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pSdp),
+	switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
+	switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
+	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
+	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason));
+
+janus_id_t apiGetServerId(server_t *pServer);
+switch_status_t apiClaimServerId(server_t *pServer, janus_id_t serverId);
+janus_id_t apiGetSenderId(server_t *pServer, const janus_id_t serverId, const char *callId);
+janus_id_t apiCreateRoom(server_t *pServer, const janus_id_t serverId,
+	const janus_id_t senderId, const janus_id_t roomId, const char *pDescription,
+	switch_bool_t record, const char *pRecordingFile, const char *pPin, const char *pRoomIdStr);
+switch_status_t apiJoin(server_t *pServer, int hmacTokenTtl,
+	const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId,
+	const char *pDisplay, const char *pPin, const char *pToken, const char *callId, const char *pRoomIdStr);
+switch_status_t apiConfigure(server_t *pServer,
+	const janus_id_t serverId, const janus_id_t senderId, const switch_bool_t muted,
+	switch_bool_t record, const char *pRecordingFile,
+	const char *pType, const char *pSdp, const char *callId);
+switch_status_t apiLeave(server_t *pServer, const janus_id_t serverId, const janus_id_t senderId, const char *callId);
+switch_status_t apiDetach(server_t *pServer, const janus_id_t serverId, const janus_id_t senderId);
+switch_status_t apiPoll(server_t *pServer, const janus_id_t serverId,
+	switch_status_t (*pJoinedFunc)(const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const janus_id_t participantId),
+	switch_status_t (*pAcceptedFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pSdp),
+	switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
+	switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
+	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
+	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason));
 
 #endif //_API_H_
 /* For Emacs:

--- a/autoload_conf/janus.conf.xml
+++ b/autoload_conf/janus.conf.xml
@@ -3,8 +3,20 @@
     <param name="debug" value="false"/>
   </settings>
 
+  <!--
+    Janus API URL (param name="url"):
+    - http://  or https://  — REST (long-poll events). Default transport; uses libcurl.
+    - ws://    or wss://    — WebSocket API (janus-protocol). Requires mod_janus built with libks
+      (libks2 or libks). Port and path must match your Janus WebSockets transport (often different
+      from the HTTP REST port). wss:// uses the system default CA store for TLS verification.
+    Other params are unchanged. auth-token is sent as a JSON "token" field on WebSocket requests
+    when set.
+  -->
   <server name="demo">
     <param name="url" value="https://janus.conf.meetecho.com/janus"/>
+    <!-- WebSocket example (uncomment and adjust host/port/path; build must link libks):
+    <param name="url" value="wss://janus.example.com:8989/"/>
+    -->
     <!-- <param name="secret" value="the-secret"/> -->
     <!-- <param name="auth-token" value="the-auth-token"/> -->
     <!--

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,18 @@ AS_VAR_IF([$1], [""], [$4], [$3])dnl
 ])# PKG_CHECK_VAR
 
 PKG_CHECK_MODULES([FREESWITCH],[freeswitch],[],[])
+
+have_ks=no
+PKG_CHECK_MODULES([KS], [libks2 >= 2.0.0], [have_ks=yes], [:])
+if test "x$have_ks" != xyes; then
+  PKG_CHECK_MODULES([KS], [libks >= 1.8.2], [have_ks=yes], [:])
+fi
+if test "x$have_ks" != xyes; then
+  KS_CFLAGS=""
+  KS_LIBS=""
+fi
+AM_CONDITIONAL([HAVE_KS], [test "x$have_ks" = xyes])
+
 PKG_CHECK_VAR([moddir],[freeswitch],[modulesdir])
 PKG_CHECK_VAR([confdir],[freeswitch],[confdir])
 PKG_CHECK_VER([version],[freeswitch])
@@ -50,6 +62,8 @@ AC_SUBST(SWITCH_VERSION_MINOR, [$SWITCH_VERSION_MINOR])
 AC_SUBST(SWITCH_VERSION_MICRO, [$SWITCH_VERSION_MICRO])
 AC_SUBST(FREESWITCH_CFLAGS)
 AC_SUBST(FREESWITCH_LDFLAGS)
+AC_SUBST(KS_CFLAGS)
+AC_SUBST(KS_LIBS)
 AC_SUBST(moddir)
 AC_SUBST(confdir)
 

--- a/globals.h
+++ b/globals.h
@@ -62,6 +62,9 @@ typedef struct {
 	} \
 } while (0)
 
+/* Verbose tracing in api.c / hash.c: always DEBUG level (not promoted when mod_janus debug=true). */
+#define MOD_JANUS_DBG(details, ...) switch_log_printf(details, SWITCH_LOG_DEBUG, __VA_ARGS__)
+
 extern globals_t globals;
 
 #endif //_GLOBALS_H_

--- a/janus_ws.c
+++ b/janus_ws.c
@@ -1,0 +1,543 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ * Copyright (C) 2005-2014, Anthony Minessale II <anthm@freeswitch.org>
+ *
+ * Version: MPL 1.1
+ *
+ * janus_ws.c -- Janus WebSocket transport via libks.
+ *
+ * Design:
+ *   - One persistent WebSocket per server_t (server->janus_ws_handle).
+ *   - All socket I/O (write + poll + read) is serialized under ctx->io_mutex.
+ *   - Because io_mutex makes every RPC strictly serial, the ctx only tracks
+ *     ONE in-flight RPC transaction (ctx->rpc_txn / ctx->rpc_result) instead
+ *     of a hash/cond/per-request subpool.
+ *   - Non-RPC frames arriving during a sync RPC are stashed on ctx->deferred
+ *     and dispatched by the next pump iteration, so Janus events are never
+ *     silently dropped.
+ */
+#if defined(HAVE_MOD_JANUS_WS)
+
+#include "libks/ks.h"
+#include "janus_ws.h"
+#include "api.h"
+#include "cJSON.h"
+#include "globals.h"
+#include "switch_stun.h"
+
+#define JANUS_WS_DEFAULT_RPC_US (15 * 1000000)
+
+/* Max time the pump holds io_mutex across kws_wait_sock before releasing it
+ * so RPC callers can interleave. 200 ms gives decent responsiveness while
+ * keeping syscall overhead negligible. */
+#define JANUS_WS_PUMP_SLICE_MS  200
+
+typedef struct janus_ws_deferred_s {
+	cJSON *root;
+	struct janus_ws_deferred_s *next;
+} janus_ws_deferred_t;
+
+typedef struct {
+	server_t *server;
+	kws_t *kws;
+	ks_pool_t *kpool;
+	switch_mutex_t *io_mutex; /* serializes all kws_* I/O */
+	switch_memory_pool_t *pool;
+
+	/* Current synchronous RPC, protected by io_mutex. */
+	const char *rpc_txn;
+	cJSON *rpc_result;
+
+	/* Non-RPC frames captured during an RPC; dispatched by the pump. */
+	janus_ws_deferred_t *deferred_head;
+	janus_ws_deferred_t *deferred_tail;
+} janus_ws_ctx_t;
+
+/* -------------------------------------------------------------------------- */
+/* libks global init refcount                                                 */
+/* -------------------------------------------------------------------------- */
+
+static switch_mutex_t *g_libks_ref_mutex = NULL;
+static int g_libks_refs = 0;
+
+static void janus_ws_libks_acquire(switch_memory_pool_t *pool)
+{
+	if (!g_libks_ref_mutex) {
+		switch_mutex_init(&g_libks_ref_mutex, SWITCH_MUTEX_NESTED, pool);
+	}
+	switch_mutex_lock(g_libks_ref_mutex);
+	if (g_libks_refs++ == 0) {
+		ks_ssl_init_skip(KS_TRUE);
+		ks_init();
+	}
+	switch_mutex_unlock(g_libks_ref_mutex);
+}
+
+static void janus_ws_libks_release(void)
+{
+	if (!g_libks_ref_mutex) {
+		return;
+	}
+	switch_mutex_lock(g_libks_ref_mutex);
+	if (g_libks_refs > 0 && --g_libks_refs == 0) {
+		ks_shutdown();
+	}
+	switch_mutex_unlock(g_libks_ref_mutex);
+}
+
+void janus_ws_mod_global_shutdown(void)
+{
+	if (!g_libks_ref_mutex) {
+		return;
+	}
+	switch_mutex_lock(g_libks_ref_mutex);
+	if (g_libks_refs > 0) {
+		g_libks_refs = 0;
+		ks_shutdown();
+	}
+	switch_mutex_unlock(g_libks_ref_mutex);
+}
+
+/* -------------------------------------------------------------------------- */
+/* helpers                                                                    */
+/* -------------------------------------------------------------------------- */
+
+static janus_ws_ctx_t *janus_ws_ctx_get(server_t *server)
+{
+	return server ? (janus_ws_ctx_t *) server->janus_ws_handle : NULL;
+}
+
+static void janus_ws_dbg_json(const char *dir, const char *json)
+{
+	if (json && *json) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "janus_ws %s %s\n", dir, json);
+	}
+}
+
+/* Add `root` to the deferred list. Takes ownership on success; caller must
+ * cJSON_Delete(root) if this returns SWITCH_FALSE. */
+static switch_bool_t janus_ws_defer_event(janus_ws_ctx_t *ctx, cJSON *root)
+{
+	janus_ws_deferred_t *node = malloc(sizeof(*node));
+	if (!node) {
+		return SWITCH_FALSE;
+	}
+	node->root = root;
+	node->next = NULL;
+	if (ctx->deferred_tail) {
+		ctx->deferred_tail->next = node;
+	} else {
+		ctx->deferred_head = node;
+	}
+	ctx->deferred_tail = node;
+	return SWITCH_TRUE;
+}
+
+/* Test whether `root` is the reply for the currently in-flight RPC (ctx->rpc_txn).
+ * Takes ownership of `root` and stashes it on ctx->rpc_result on match. */
+static switch_bool_t janus_ws_match_rpc_reply(janus_ws_ctx_t *ctx, cJSON *root)
+{
+	cJSON *txn;
+	cJSON *jt;
+
+	if (!ctx->rpc_txn) {
+		return SWITCH_FALSE;
+	}
+	txn = cJSON_GetObjectItemCaseSensitive(root, "transaction");
+	jt  = cJSON_GetObjectItemCaseSensitive(root, "janus");
+	if (!cJSON_IsString(txn) || !cJSON_IsString(jt)) {
+		return SWITCH_FALSE;
+	}
+	if (strcmp(txn->valuestring, ctx->rpc_txn) != 0) {
+		return SWITCH_FALSE;
+	}
+	if (strcmp(jt->valuestring, "success") &&
+		strcmp(jt->valuestring, "ack") &&
+		strcmp(jt->valuestring, "error")) {
+		return SWITCH_FALSE;
+	}
+	ctx->rpc_result = root;
+	return SWITCH_TRUE;
+}
+
+/* -------------------------------------------------------------------------- */
+/* drain                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/* Read every frame currently available on the socket.
+ *
+ * For each TEXT frame:
+ *   - If it matches the in-flight RPC transaction: store on ctx->rpc_result.
+ *   - Else if `dispatch` is non-NULL: dispatch via api_dispatch_poll_event.
+ *   - Else: append to ctx->deferred for the pump to process later.
+ *
+ * Caller MUST hold ctx->io_mutex.
+ */
+typedef struct {
+	switch_status_t (*joined)(const janus_id_t, const janus_id_t, const janus_id_t, const janus_id_t);
+	switch_status_t (*accepted)(const janus_id_t, const janus_id_t, const char *);
+	switch_status_t (*trickle)(const janus_id_t, const janus_id_t, const char *);
+	switch_bool_t   (*answer_on_webrtcup)(const janus_id_t, const janus_id_t);
+	switch_status_t (*answered)(const janus_id_t, const janus_id_t);
+	switch_status_t (*hungup)(const janus_id_t, const janus_id_t, const char *);
+} janus_ws_dispatch_t;
+
+static void janus_ws_dispatch_event(cJSON *root, const janus_ws_dispatch_t *d)
+{
+	(void) api_dispatch_poll_event(root,
+		d->joined, d->accepted, d->trickle, d->answer_on_webrtcup, d->answered, d->hungup);
+	cJSON_Delete(root);
+}
+
+static switch_status_t janus_ws_drain(janus_ws_ctx_t *ctx, const janus_ws_dispatch_t *dispatch)
+{
+	for (;;) {
+		kws_opcode_t oc = WSOC_INVALID;
+		uint8_t *data = NULL;
+		ks_ssize_t bytes;
+		char *text;
+		cJSON *root;
+
+		/*
+		 * libks kws_read_frame blocks for WS_BLOCK (10 s) when the socket is
+		 * idle, and on timeout it returns -1 AND closes the underlying socket
+		 * (via kws_close). To stay non-blocking, peek with a 0 ms poll first
+		 * and only call kws_read_frame when we know data is ready. This also
+		 * picks up kws->unprocessed_buffer_len / SSL_pending via kws_wait_sock.
+		 */
+		{
+			int pr = kws_wait_sock(ctx->kws, 0, KS_POLL_READ);
+			if (pr < 0 || (pr & KS_POLL_INVALID) || ((pr & KS_POLL_ERROR) && !(pr & KS_POLL_READ))) {
+				return SWITCH_STATUS_FALSE;
+			}
+			if (!(pr & KS_POLL_READ)) {
+				return SWITCH_STATUS_SUCCESS;
+			}
+		}
+
+		bytes = kws_read_frame(ctx->kws, &oc, &data);
+		if (bytes < 0) {
+			return SWITCH_STATUS_FALSE;
+		}
+		if (bytes == 0) {
+			return SWITCH_STATUS_SUCCESS;
+		}
+		if (oc != WSOC_TEXT) {
+			continue;
+		}
+
+		text = malloc((size_t) bytes + 1);
+		if (!text) {
+			return SWITCH_STATUS_FALSE;
+		}
+		memcpy(text, data, (size_t) bytes);
+		text[bytes] = '\0';
+		janus_ws_dbg_json("recv", text);
+
+		root = cJSON_Parse(text);
+		free(text);
+		if (!root) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "janus_ws: invalid JSON\n");
+			continue;
+		}
+
+		if (janus_ws_match_rpc_reply(ctx, root)) {
+			continue; /* owned by ctx->rpc_result */
+		}
+		if (dispatch) {
+			janus_ws_dispatch_event(root, dispatch);
+		} else if (!janus_ws_defer_event(ctx, root)) {
+			cJSON_Delete(root);
+		}
+	}
+}
+
+static void janus_ws_flush_deferred(janus_ws_ctx_t *ctx, const janus_ws_dispatch_t *dispatch)
+{
+	janus_ws_deferred_t *node = ctx->deferred_head;
+	ctx->deferred_head = ctx->deferred_tail = NULL;
+	while (node) {
+		janus_ws_deferred_t *next = node->next;
+		if (dispatch) {
+			janus_ws_dispatch_event(node->root, dispatch);
+		} else {
+			cJSON_Delete(node->root);
+		}
+		free(node);
+		node = next;
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* public: synchronous RPC                                                    */
+/* -------------------------------------------------------------------------- */
+
+cJSON *janus_ws_rpc_json(server_t *server, cJSON *request, const char *transaction, switch_interval_time_t timeout_us)
+{
+	janus_ws_ctx_t *ctx = janus_ws_ctx_get(server);
+	char *payload = NULL;
+	cJSON *result = NULL;
+	switch_time_t deadline;
+
+	if (!ctx || !ctx->kws || !request || !transaction) {
+		return NULL;
+	}
+
+	switch_mutex_lock(ctx->io_mutex);
+
+	payload = cJSON_PrintUnformatted(request);
+	if (!payload) {
+		switch_mutex_unlock(ctx->io_mutex);
+		return NULL;
+	}
+	janus_ws_dbg_json("send", payload);
+
+	if (kws_write_frame(ctx->kws, WSOC_TEXT, payload, strlen(payload)) < 0) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "janus_ws: write failed\n");
+		cJSON_free(payload);
+		switch_mutex_unlock(ctx->io_mutex);
+		return NULL;
+	}
+	cJSON_free(payload);
+
+	ctx->rpc_txn    = transaction;
+	ctx->rpc_result = NULL;
+
+	deadline = switch_time_now() + timeout_us;
+	while (!ctx->rpc_result && switch_time_now() < deadline) {
+		switch_interval_time_t remaining = deadline - switch_time_now();
+		uint32_t slice_ms = (uint32_t) ((remaining < 100000 ? remaining : 100000) / 1000);
+		int pr = kws_wait_sock(ctx->kws, slice_ms, KS_POLL_READ);
+
+		if (pr < 0 || (pr & KS_POLL_INVALID) || ((pr & KS_POLL_ERROR) && !(pr & KS_POLL_READ))) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+				"janus_ws: RPC wait poll error pr=%d\n", pr);
+			break;
+		}
+		if ((pr & KS_POLL_READ) && janus_ws_drain(ctx, NULL) != SWITCH_STATUS_SUCCESS) {
+			break;
+		}
+	}
+
+	if (!ctx->rpc_result) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+			"janus_ws: RPC timeout transaction=%s\n", transaction);
+	}
+
+	result = ctx->rpc_result;
+	ctx->rpc_txn    = NULL;
+	ctx->rpc_result = NULL;
+
+	switch_mutex_unlock(ctx->io_mutex);
+	return result;
+}
+
+/* -------------------------------------------------------------------------- */
+/* public: event pump                                                         */
+/* -------------------------------------------------------------------------- */
+
+switch_status_t janus_ws_pump_once(server_t *server, janus_id_t session_id,
+	switch_interval_time_t wait_us,
+	switch_interval_time_t keepalive_interval_us,
+	switch_time_t *last_activity_ref,
+	switch_status_t (*pJoinedFunc)(const janus_id_t, const janus_id_t, const janus_id_t, const janus_id_t),
+	switch_status_t (*pAcceptedFunc)(const janus_id_t, const janus_id_t, const char *),
+	switch_status_t (*pTrickleFunc)(const janus_id_t, const janus_id_t, const char *),
+	switch_bool_t   (*pAnswerOnWebrtcupFunc)(const janus_id_t, const janus_id_t),
+	switch_status_t (*pAnsweredFunc)(const janus_id_t, const janus_id_t),
+	switch_status_t (*pHungupFunc)(const janus_id_t, const janus_id_t, const char *))
+{
+	janus_ws_ctx_t *ctx = janus_ws_ctx_get(server);
+	janus_ws_dispatch_t dispatch;
+	int pr;
+
+	if (!ctx || !ctx->kws) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	dispatch.joined             = pJoinedFunc;
+	dispatch.accepted           = pAcceptedFunc;
+	dispatch.trickle            = pTrickleFunc;
+	dispatch.answer_on_webrtcup = pAnswerOnWebrtcupFunc;
+	dispatch.answered           = pAnsweredFunc;
+	dispatch.hungup             = pHungupFunc;
+
+	/* Keepalive. Nested RPC re-enters io_mutex (NESTED), then drain happens below. */
+	if (keepalive_interval_us > 0 && session_id && last_activity_ref && *last_activity_ref > 0 &&
+		(switch_time_now() - *last_activity_ref) > keepalive_interval_us) {
+		cJSON *ka = cJSON_CreateObject();
+		if (ka) {
+			char txn[17] = {0};
+			char sid[32];
+			cJSON *resp;
+			switch_stun_random_string(txn, sizeof(txn) - 1, NULL);
+			cJSON_AddStringToObject(ka, "janus", "keepalive");
+			(void) snprintf(sid, sizeof(sid), "%" SWITCH_UINT64_T_FMT, (uint64_t) session_id);
+			cJSON_AddRawToObject(ka, "session_id", sid);
+			cJSON_AddStringToObject(ka, "transaction", txn);
+			if (server->pSecret) {
+				cJSON_AddStringToObject(ka, "apisecret", server->pSecret);
+			}
+			resp = janus_ws_rpc_json(server, ka, txn, JANUS_WS_DEFAULT_RPC_US);
+			cJSON_Delete(ka);
+			if (resp) {
+				cJSON_Delete(resp);
+			}
+			*last_activity_ref = switch_time_now();
+		}
+	}
+
+	/*
+	 * Slice the long pump wait into short windows so that concurrent RPC
+	 * callers (attach, createroom, joinroom, hangup, ...) can acquire
+	 * ctx->io_mutex between slices. Holding the mutex across a full
+	 * wait_us (up to 60 s) would starve all outbound RPCs — exactly the
+	 * "attach queued but not sent until next pump iteration" symptom.
+	 *
+	 * Slice length is capped at JANUS_WS_PUMP_SLICE_MS. Between slices we
+	 * release the mutex, yield, and re-check. If data becomes available we
+	 * drain it and return promptly so the outer loop can decide what to do.
+	 */
+	{
+		const switch_time_t deadline = switch_time_now() + wait_us;
+		for (;;) {
+			const switch_interval_time_t remain_us = deadline - switch_time_now();
+			uint32_t slice_ms;
+
+			if (remain_us <= 0) {
+				return SWITCH_STATUS_SUCCESS;
+			}
+			/* Clamp: never hold io_mutex longer than JANUS_WS_PUMP_SLICE_MS. */
+			slice_ms = (remain_us < (JANUS_WS_PUMP_SLICE_MS * 1000))
+				? (uint32_t) (remain_us / 1000)
+				: JANUS_WS_PUMP_SLICE_MS;
+			if (slice_ms == 0) {
+				slice_ms = 1;
+			}
+
+			switch_mutex_lock(ctx->io_mutex);
+
+			janus_ws_flush_deferred(ctx, &dispatch);
+
+			pr = kws_wait_sock(ctx->kws, slice_ms, KS_POLL_READ);
+			if (pr < 0 || (pr & KS_POLL_INVALID) ||
+				((pr & (KS_POLL_ERROR | KS_POLL_HUP)) && !(pr & KS_POLL_READ))) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+					"janus_ws: pump poll failed pr=%d (0x%x) slice_ms=%u\n",
+					pr, (unsigned) pr, slice_ms);
+				switch_mutex_unlock(ctx->io_mutex);
+				return SWITCH_STATUS_FALSE;
+			}
+			if (pr & KS_POLL_READ) {
+				if (janus_ws_drain(ctx, &dispatch) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "janus_ws: pump drain failed\n");
+					switch_mutex_unlock(ctx->io_mutex);
+					return SWITCH_STATUS_FALSE;
+				}
+				if (last_activity_ref) {
+					*last_activity_ref = switch_time_now();
+				}
+				switch_mutex_unlock(ctx->io_mutex);
+				return SWITCH_STATUS_SUCCESS;
+			}
+
+			switch_mutex_unlock(ctx->io_mutex);
+			/* Brief yield so any thread blocked on io_mutex wins the next round. */
+			switch_cond_next();
+		}
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* public: connect / disconnect                                               */
+/* -------------------------------------------------------------------------- */
+
+switch_status_t janus_ws_server_open(server_t *server)
+{
+	janus_ws_ctx_t *ctx;
+	switch_memory_pool_t *ctx_pool = NULL;
+	ks_json_t *params;
+	ks_status_t kst;
+
+	if (!server) {
+		return SWITCH_STATUS_FALSE;
+	}
+	if (server->janus_ws_handle) {
+		return SWITCH_STATUS_SUCCESS;
+	}
+
+	janus_ws_libks_acquire(globals.pModulePool);
+
+	if (switch_core_new_memory_pool(&ctx_pool) != SWITCH_STATUS_SUCCESS) {
+		janus_ws_libks_release();
+		return SWITCH_STATUS_FALSE;
+	}
+	ctx = switch_core_alloc(ctx_pool, sizeof(*ctx));
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->server = server;
+	ctx->pool   = ctx_pool;
+	switch_mutex_init(&ctx->io_mutex, SWITCH_MUTEX_NESTED, ctx->pool);
+
+	if (ks_pool_open(&ctx->kpool) != KS_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "janus_ws: ks_pool_open failed\n");
+		goto fail;
+	}
+
+	params = ks_json_create_object();
+	ks_json_add_string_to_object(params, "url",      server->pUrl);
+	ks_json_add_string_to_object(params, "protocol", "janus-protocol");
+#if defined(KS_VERSION_NUM) && KS_VERSION_NUM >= 20000
+	ks_json_add_number_to_object(params, "payload_size_max", 1000000);
+#endif
+	kst = kws_connect_ex(&ctx->kws, params, KWS_BLOCK, ctx->kpool, NULL, 30000);
+	ks_json_delete(&params);
+
+	if (kst != KS_STATUS_SUCCESS || !ctx->kws) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "janus_ws: connect failed for %s\n", server->pUrl);
+		goto fail;
+	}
+
+	server->janus_ws_handle = ctx;
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+		"janus_ws: connected server=%s url=%s\n", server->name, server->pUrl);
+	return SWITCH_STATUS_SUCCESS;
+
+fail:
+	if (ctx->kws) {
+		kws_destroy(&ctx->kws);
+	}
+	if (ctx->kpool) {
+		ks_pool_close(&ctx->kpool);
+	}
+	switch_mutex_destroy(ctx->io_mutex);
+	switch_core_destroy_memory_pool(&ctx->pool);
+	janus_ws_libks_release();
+	return SWITCH_STATUS_FALSE;
+}
+
+void janus_ws_server_close(server_t *server)
+{
+	janus_ws_ctx_t *ctx = janus_ws_ctx_get(server);
+
+	if (!ctx) {
+		return;
+	}
+	server->janus_ws_handle = NULL;
+
+	if (ctx->kws) {
+		kws_close(ctx->kws, WS_NONE);
+		kws_destroy(&ctx->kws);
+	}
+	if (ctx->kpool) {
+		ks_pool_close(&ctx->kpool);
+	}
+	if (ctx->rpc_result) {
+		cJSON_Delete(ctx->rpc_result);
+	}
+	janus_ws_flush_deferred(ctx, NULL);
+	switch_mutex_destroy(ctx->io_mutex);
+	switch_core_destroy_memory_pool(&ctx->pool);
+	janus_ws_libks_release();
+}
+
+#endif /* HAVE_MOD_JANUS_WS */

--- a/janus_ws.h
+++ b/janus_ws.h
@@ -1,0 +1,42 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ * Copyright (C) 2005-2014, Anthony Minessale II <anthm@freeswitch.org>
+ *
+ * Version: MPL 1.1
+ *
+ * janus_ws.h -- Janus WebSocket transport (libks) for mod_janus
+ */
+#ifndef MOD_JANUS_JANUS_WS_H
+#define MOD_JANUS_JANUS_WS_H
+
+#include "servers.h"
+
+#if defined(HAVE_MOD_JANUS_WS)
+
+void janus_ws_mod_global_shutdown(void);
+
+switch_status_t janus_ws_server_open(server_t *server);
+void janus_ws_server_close(server_t *server);
+
+/* Synchronous request/response over the shared WebSocket (blocking). */
+cJSON *janus_ws_rpc_json(server_t *server, cJSON *request, const char *transaction, switch_interval_time_t timeout_us);
+
+/*
+ * Block until one WS text frame is received and processed, or timeout.
+ * Dispatches async Janus messages to the same callbacks as apiPoll.
+ * Sends keepalive when idle longer than keepalive_interval_us.
+ */
+switch_status_t janus_ws_pump_once(server_t *server, janus_id_t session_id,
+	switch_interval_time_t wait_us,
+	switch_interval_time_t keepalive_interval_us,
+	switch_time_t *last_activity_ref,
+	switch_status_t (*pJoinedFunc)(const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const janus_id_t participantId),
+	switch_status_t (*pAcceptedFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pSdp),
+	switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
+	switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
+	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
+	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason));
+
+#endif /* HAVE_MOD_JANUS_WS */
+
+#endif /* MOD_JANUS_JANUS_WS_H */

--- a/mod_janus.c
+++ b/mod_janus.c
@@ -41,6 +41,9 @@
 #include	"servers.h"
 #include	"api.h"
 #include	"hash.h"
+#if defined(HAVE_MOD_JANUS_WS)
+#include	"janus_ws.h"
+#endif
 
 SWITCH_MODULE_LOAD_FUNCTION(mod_janus_load);
 SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_janus_shutdown);
@@ -193,10 +196,8 @@ switch_status_t joined(janus_id_t serverId, janus_id_t senderId, janus_id_t room
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Generated SDP=%s\n", tech_pvt->mparams.local_sdp_str);
 
-	if (apiConfigure(pServer->pUrl, 
-					pServer->pSecret,
-					pServer->pHmacSecret,
-					tech_pvt->serverId, 
+	if (apiConfigure(pServer,
+					tech_pvt->serverId,
 					tech_pvt->senderId,
 					switch_channel_var_true(channel, "janus-start-muted"),
 					switch_channel_var_true(channel, "janus-user-record"),
@@ -411,9 +412,20 @@ switch_status_t hungup(janus_id_t serverId, janus_id_t senderId, const char *pRe
 	return SWITCH_STATUS_SUCCESS;
 }
 
+/* Human-readable transport label for log lines. */
+static const char *transport_name(const server_t *pServer) {
+#if defined(HAVE_MOD_JANUS_WS)
+	return (pServer && pServer->transport == JANUS_TP_WS) ? "WebSocket session" : "HTTP long-poll";
+#else
+	(void) pServer;
+	return "HTTP long-poll";
+#endif
+}
+
 static void *SWITCH_THREAD_FUNC server_thread_run(switch_thread_t *pThread, void *pObj) {
 	server_t *pServer = (server_t *) pObj;
 	janus_id_t serverId = 0;
+	int outer_reconnect_delay = 0;
 
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Thread started - server=%s\n", pServer->name);
 
@@ -422,22 +434,48 @@ static void *SWITCH_THREAD_FUNC server_thread_run(switch_thread_t *pThread, void
 	while (!switch_test_flag(pServer, SFLAG_TERMINATING)) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Server=%s invoking\n", pServer->name);
 
-		// wait for a few seconds before re-connection
-		switch_yield(5000000);
+		/* Back off before *re*connect attempts only. First pass must register immediately or outbound janus/... finds serverId=0. */
+		if (outer_reconnect_delay) {
+			switch_yield(5000000);
+		}
+		outer_reconnect_delay = 1;
+
+#if defined(HAVE_MOD_JANUS_WS)
+		/*
+		 * One persistent WebSocket per server: open only when there is no handle.
+		 * Session recovery uses Janus "claim" (and keepalives inside the pump), not TCP churn.
+		 * Close the socket only on transport-level failure (see claim SOCKERR / create failure below).
+		 */
+		if (pServer->transport == JANUS_TP_WS && !pServer->janus_ws_handle) {
+			if (janus_ws_server_open(pServer) != SWITCH_STATUS_SUCCESS) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Server=%s WebSocket connect failed\n", pServer->name);
+				continue;
+			}
+		}
+#endif
 
 		if (serverId) {
 			// the connection or Janus has restarted - try to re-use the same serverId
-			switch_status_t status =  apiClaimServerId(pServer->pUrl, pServer->pSecret, pServer->pHmacSecret, serverId);
+			switch_status_t status =  apiClaimServerId(pServer, serverId);
 			if (status == SWITCH_STATUS_SOCKERR) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Server=%s claim socket error - retry later\n", pServer->name);
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Server=%s claim socket error - closing WebSocket, will reconnect\n", pServer->name);
+#if defined(HAVE_MOD_JANUS_WS)
+				if (pServer->transport == JANUS_TP_WS && pServer->janus_ws_handle) {
+					janus_ws_server_close(pServer);
+				}
+#endif
 			} else if (status == SWITCH_STATUS_SUCCESS) {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Server=%s claim success - serverId=%" SWITCH_UINT64_T_FMT "\n", pServer->name, serverId);
-				if (hashInsert(&globals.serverIdLookup, serverId, (void *) pServer) != SWITCH_STATUS_SUCCESS) {
-					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't insert server into hash table\n");
-				}
 				switch_mutex_lock(pServer->mutex);
 				pServer->serverId = serverId;
 				switch_mutex_unlock(pServer->mutex);
+				if (hashInsert(&globals.serverIdLookup, serverId, (void *) pServer) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't insert server into hash table\n");
+					switch_mutex_lock(pServer->mutex);
+					pServer->serverId = 0;
+					switch_mutex_unlock(pServer->mutex);
+					serverId = 0;
+				}
 			} else {
 				// terminate all calls in progress on this server
 				switch_core_session_t *session;
@@ -460,26 +498,45 @@ static void *SWITCH_THREAD_FUNC server_thread_run(switch_thread_t *pThread, void
 				serverId = 0;
 			}
 		} else {
-			// first time
-			serverId = apiGetServerId(pServer->pUrl, pServer->pSecret, pServer->pHmacSecret);
+			// first time (or new session after claim loss)
+			serverId = apiGetServerId(pServer);
 			if (!serverId) {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Error getting serverId\n");
-			} else if (hashInsert(&globals.serverIdLookup, serverId, (void *) pServer) != SWITCH_STATUS_SUCCESS) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't insert server into hash table\n");
+#if defined(HAVE_MOD_JANUS_WS)
+				/* Stale transport after Janus restart etc.: drop TCP so next loop opens a clean socket. */
+				if (pServer->transport == JANUS_TP_WS && pServer->janus_ws_handle) {
+					janus_ws_server_close(pServer);
+				}
+#endif
 			} else {
 				switch_mutex_lock(pServer->mutex);
 				pServer->started = switch_time_now();
 				pServer->serverId = serverId;
 				pServer->callsInProgress = 0;
 				switch_mutex_unlock(pServer->mutex);
+				if (hashInsert(&globals.serverIdLookup, serverId, (void *) pServer) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't insert server into hash table\n");
+					switch_mutex_lock(pServer->mutex);
+					pServer->serverId = 0;
+					switch_mutex_unlock(pServer->mutex);
+					serverId = 0;
+				}
 			}
 		}
 
-		while (!switch_test_flag(pServer, SFLAG_TERMINATING) && hashFind(&globals.serverIdLookup, serverId)) {
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Poll started, serverId: %ld\n", (long)serverId);
+#if defined(HAVE_MOD_JANUS_WS)
+		if (pServer->transport == JANUS_TP_WS) {
+			pServer->ws_last_poll = switch_time_now();
+		}
+#endif
 
-			if (apiPoll(pServer->pUrl, pServer->pSecret, pServer->pHmacSecret, serverId, pServer->pAuthToken, joined, accepted, trickle, answer_on_webrtcup, answered, hungup) != SWITCH_STATUS_SUCCESS) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Poll failed, serverId: %ld\n", (long)serverId);
+		while (!switch_test_flag(pServer, SFLAG_TERMINATING) && hashFind(&globals.serverIdLookup, serverId)) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
+				"Janus %s started (id=%" SWITCH_UINT64_T_FMT ")\n", transport_name(pServer), (janus_id_t)serverId);
+
+			if (apiPoll(pServer, serverId, joined, accepted, trickle, answer_on_webrtcup, answered, hungup) != SWITCH_STATUS_SUCCESS) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+					"Janus %s failed (id=%" SWITCH_UINT64_T_FMT ")\n", transport_name(pServer), (janus_id_t)serverId);
 				if (hashDelete(&globals.serverIdLookup, serverId) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't remove server %ld from hash table\n", (long)serverId);
 				}
@@ -488,13 +545,20 @@ static void *SWITCH_THREAD_FUNC server_thread_run(switch_thread_t *pThread, void
 				pServer->serverId = 0;
 				switch_mutex_unlock(pServer->mutex);
 			} else {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Poll completed, serverId: %ld\n", (long)serverId);
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
+					"Janus %s completed (id=%" SWITCH_UINT64_T_FMT ")\n", transport_name(pServer), (janus_id_t)serverId);
 			}
 		}
 	}
 	(void) hashDestroy(&pServer->senderIdLookup);
 
 	(void) hashDelete(&globals.serverIdLookup, serverId);
+
+#if defined(HAVE_MOD_JANUS_WS)
+	if (pServer->transport == JANUS_TP_WS) {
+		janus_ws_server_close(pServer);
+	}
+#endif
 
 	return NULL;
 }
@@ -607,7 +671,7 @@ static switch_status_t channel_on_init(switch_core_session_t *session)
 		return SWITCH_STATUS_NOTFOUND;
 	}
 
-	tech_pvt->senderId = apiGetSenderId(pServer->pUrl, pServer->pSecret, pServer->pHmacSecret, tech_pvt->serverId, tech_pvt->callId);
+	tech_pvt->senderId = apiGetSenderId(pServer, tech_pvt->serverId, tech_pvt->callId);
 	if (!tech_pvt->senderId) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error getting senderId\n");
 		switch_channel_hangup(channel, SWITCH_CAUSE_INCOMPATIBLE_DESTINATION);
@@ -625,7 +689,7 @@ static switch_status_t channel_on_init(switch_core_session_t *session)
 	}
 
 	if (switch_channel_var_false(channel, "janus-use-existing-room")) {
-		if (apiCreateRoom(pServer->pUrl, pServer->pSecret, pServer->pHmacSecret, tech_pvt->serverId, tech_pvt->senderId, tech_pvt->roomId,
+		if (apiCreateRoom(pServer, tech_pvt->serverId, tech_pvt->senderId, tech_pvt->roomId,
 						switch_channel_get_variable(channel, "janus-room-description"),
 						switch_channel_var_true(channel, "janus-room-record"),
 						switch_channel_get_variable(channel, "janus-room-record-file"),
@@ -706,9 +770,7 @@ static switch_status_t channel_on_routing(switch_core_session_t *session)
 	}
 
 	if (apiJoin(
-				pServer->pUrl,
-				pServer->pSecret,
-				pServer->pHmacSecret,
+				pServer,
 				hmacTokenTtl,
 				tech_pvt->serverId,
 				tech_pvt->senderId,
@@ -816,12 +878,12 @@ static switch_status_t channel_on_hangup(switch_core_session_t *session)
 		return SWITCH_STATUS_NOTFOUND;
 	}
 
-	if (apiLeave(pServer->pUrl, pServer->pSecret, pServer->pHmacSecret, tech_pvt->serverId, tech_pvt->senderId, tech_pvt->callId) != SWITCH_STATUS_SUCCESS) {
+	if (apiLeave(pServer, tech_pvt->serverId, tech_pvt->senderId, tech_pvt->callId) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Failed to leave room\n");
 		// carry on regardless
 	}
 
-	if (apiDetach(pServer->pUrl, pServer->pSecret, pServer->pHmacSecret, tech_pvt->serverId, tech_pvt->senderId) != SWITCH_STATUS_SUCCESS) {
+	if (apiDetach(pServer, tech_pvt->serverId, tech_pvt->senderId) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Failed to detach\n");
 		// carry on regardless
 	}
@@ -1333,6 +1395,10 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_janus_shutdown)
 	(void) serversDestroy();
 
 	switch_curl_destroy();
+
+#if defined(HAVE_MOD_JANUS_WS)
+	janus_ws_mod_global_shutdown();
+#endif
 
 	return SWITCH_STATUS_SUCCESS;
 }

--- a/servers.c
+++ b/servers.c
@@ -77,6 +77,9 @@ switch_status_t serversAdd(switch_xml_t xmlint) {
   pServer->totalCalls = 0;
   pServer->callsInProgress = 0;
   pServer->pThread = NULL;
+  pServer->transport = JANUS_TP_HTTP;
+  pServer->janus_ws_handle = NULL;
+  pServer->ws_last_poll = 0;
 
 	// set default values
 	pServer->name = switch_core_strdup(globals.pModulePool, pName);
@@ -170,6 +173,21 @@ switch_status_t serversAdd(switch_xml_t xmlint) {
 	if (!pServer->pUrl) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Server=%s  Mandatory parameter not specified\n", pName);
 		return SWITCH_STATUS_FALSE;
+	}
+
+	if (!strncasecmp(pServer->pUrl, "ws://", 5) || !strncasecmp(pServer->pUrl, "wss://", 6)) {
+#if defined(HAVE_MOD_JANUS_WS)
+		pServer->transport = JANUS_TP_WS;
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+				"Server=%s  WebSocket transport selected (url=%s)\n", pName, pServer->pUrl);
+#else
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+				"Server=%s  WebSocket URL '%s' but mod_janus was built without libks support\n",
+				pName, pServer->pUrl);
+		return SWITCH_STATUS_FALSE;
+#endif
+	} else {
+		pServer->transport = JANUS_TP_HTTP;
 	}
 
 	if (pServer->pHmacSecret && pServer->pAuthToken) {

--- a/servers.h
+++ b/servers.h
@@ -42,7 +42,12 @@ typedef enum {
 	SFLAG_AUTO_NAT       = (1 << 2)
 } SFLAGS;
 
-typedef struct {
+typedef enum {
+	JANUS_TP_HTTP = 0,
+	JANUS_TP_WS
+} janus_transport_t;
+
+typedef struct server_s {
 	char *name;
 	char *pUrl;
 	char *pSecret;
@@ -80,6 +85,10 @@ typedef struct {
 	switch_time_t started;
 	unsigned int totalCalls;
 	unsigned int callsInProgress;
+
+	janus_transport_t transport;
+	void *janus_ws_handle; /* janus_ws_ctx_t when transport == JANUS_TP_WS */
+	switch_time_t ws_last_poll; /* WebSocket keepalive / activity timestamp */
 } server_t;
 
 switch_status_t serversList(const char *pLine, const char *pCursor, switch_console_callback_match_t **matches);


### PR DESCRIPTION
## Summary

Adds optional **WebSocket transport** to `mod_janus` (via SignalWire `libks` /
`libks2`). HTTP long-poll is unchanged and remains the default; WS is selected
per-server by giving a `ws://` or `wss://` URL in `janus.conf.xml`.

Build auto-detects libks via `pkg-config` — no libks, no behaviour change.

## Highlights

- **Persistent WS** per server with keepalives; `claim` on reconnect instead
  of reconnect/recreate churn.
- **New `janus_ws.{c,h}`** — unified RPC (per-txn waiters + cond var) and
  an async event pump (`joined` / `accepted` / `trickle` / `webrtcup` /
  `answered` / `hangup`).
- **`api_send_request()`** collapses 8 RPCs onto one transport-agnostic
  helper.

## Compatibility

- HTTP-only builds (no libks) are byte-for-byte equivalent to pre-PR.
- No config break for HTTP users; new WS keys are optional.
- No public FreeSWITCH API / dialstring / channel-var changes.

