### PR TITLE
Defer answer until a remote audiobridge participant is ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The following channel variables are defined:
 * janus-user-record - Janus should generate a file containing the audio from the user only.  It is specified in the *configure* request.  The default value is not to record.
 * janus-user-record-file - This specifies the base of the filename used when recording the user audio stream.  If omitted the default filename will be used.
 * janus-start-muted - Included in the *confifigure* request to indicate that the user should enter the room muted (no mechanism exists in the module to modify the mute status later).  The default value is that the user should not be muted.
+* janus-answer-on-participant-ready - When set, the SIP answer (and therefore any greeting played by the bridged leg) is deferred until another participant in the audiobridge room has negotiated its PeerConnection (`setup:true`). The module ignores its own participant id, so it waits for a genuinely remote peer (e.g. a WebRTC browser). This prevents the far end from speaking before the browser has joined and can hear audio. The default is disabled (answer as soon as the Janus leg is ready).
+* janus-answer-participant-timeout-ms - Fallback timeout (milliseconds) used with `janus-answer-on-participant-ready`: if no remote participant becomes ready within this window after the leg is otherwise answerable, the leg is answered anyway so a missing or failed peer cannot wedge the call. The default is 10000 (10 seconds).
 
 The dial string is composed of the following parts:
 ```

--- a/api.c
+++ b/api.c
@@ -398,13 +398,46 @@ static cJSON *api_send_request(server_t *pServer, cJSON *pJsonRequest, const cha
 	}
 }
 
+/* Reports each remote participant in an audiobridge "participants" array; ids are normalised to a string (numeric or string_ids rooms). */
+static void api_dispatch_participants(message_t *pResponse, cJSON *pParticipants,
+	api_participant_func_t pParticipantFunc)
+{
+	cJSON *pItem = NULL;
+
+	if (!pParticipantFunc || !cJSON_IsArray(pParticipants)) {
+		return;
+	}
+
+	cJSON_ArrayForEach(pItem, pParticipants) {
+		cJSON *pId = cJSON_GetObjectItemCaseSensitive(pItem, "id");
+		cJSON *pSetup = cJSON_GetObjectItemCaseSensitive(pItem, "setup");
+		char idBuf[64];
+		const char *pIdStr = NULL;
+		switch_bool_t setup;
+
+		if (cJSON_IsString(pId)) {
+			pIdStr = pId->valuestring;
+		} else if (cJSON_IsNumber(pId)) {
+			(void) switch_snprintf(idBuf, sizeof(idBuf), "%" SWITCH_UINT64_T_FMT, (janus_id_t) pId->valuedouble);
+			pIdStr = idBuf;
+		} else {
+			continue;
+		}
+
+		setup = cJSON_IsTrue(pSetup) ? SWITCH_TRUE : SWITCH_FALSE;
+
+		(void) pParticipantFunc(pResponse->serverId, pResponse->senderId, pIdStr, SWITCH_FALSE, setup);
+	}
+}
+
 switch_status_t api_dispatch_poll_event(cJSON *pEvent,
 	switch_status_t (*pJoinedFunc)(const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const janus_id_t participantId),
 	switch_status_t (*pAcceptedFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pSdp),
 	switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
 	switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
 	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
-	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason))
+	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason),
+	api_participant_func_t pParticipantFunc)
 {
 	message_t *pResponse = NULL;
 	cJSON *pJsonRspReason;
@@ -496,8 +529,28 @@ switch_status_t api_dispatch_poll_event(cJSON *pEvent,
 				if ((*pJoinedFunc)(pResponse->serverId, pResponse->senderId, roomId, participantId)) {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't join\n");
 				}
+
+				/* Record our own participant id so we never treat ourselves as the remote peer. */
+				if (pParticipantFunc) {
+					char selfBuf[64];
+					const char *pSelfIdStr = NULL;
+					if (cJSON_IsString(pJsonRspParticipantId)) {
+						pSelfIdStr = pJsonRspParticipantId->valuestring;
+					} else if (cJSON_IsNumber(pJsonRspParticipantId)) {
+						(void) switch_snprintf(selfBuf, sizeof(selfBuf), "%" SWITCH_UINT64_T_FMT, (janus_id_t) participantId);
+						pSelfIdStr = selfBuf;
+					}
+					if (pSelfIdStr) {
+						(void) pParticipantFunc(pResponse->serverId, pResponse->senderId, pSelfIdStr, SWITCH_TRUE, SWITCH_TRUE);
+					}
+				}
+
+				api_dispatch_participants(pResponse,
+					cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "participants"), pParticipantFunc);
 			} else {
 				MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Someone else has joined\n");
+				api_dispatch_participants(pResponse,
+					cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "participants"), pParticipantFunc);
 			}
 		} else if (!strcmp("event", pJsonRspType->valuestring)) {
 			pJsonRspType = cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "result");
@@ -549,6 +602,10 @@ switch_status_t api_dispatch_poll_event(cJSON *pEvent,
 				if ((*pHungupFunc)(pResponse->serverId, pResponse->senderId, pJsonRspError->valuestring)) {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Couldn't hangup\n");
 				}
+			} else if (cJSON_IsArray(cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "participants"))) {
+				/* Participant state change (e.g. a peer reaching setup:true) - how we learn the browser can hear audio. */
+				api_dispatch_participants(pResponse,
+					cJSON_GetObjectItemCaseSensitive(pResponse->pJsonBody, "participants"), pParticipantFunc);
 			} else {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Unknown audiobridge event\n");
 				goto end_dispatch;
@@ -1308,7 +1365,8 @@ switch_status_t apiPoll(server_t *pServer, const janus_id_t serverId,
 	switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
 	switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
 	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
-	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason))
+	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason),
+	api_participant_func_t pParticipantFunc)
 {
 	switch_status_t result = SWITCH_STATUS_SUCCESS;
 
@@ -1328,7 +1386,7 @@ switch_status_t apiPoll(server_t *pServer, const janus_id_t serverId,
 			(switch_interval_time_t)HTTP_GET_TIMEOUT * 1000,
 			(switch_interval_time_t)(25 * 1000000),
 			&pServer->ws_last_poll,
-			pJoinedFunc, pAcceptedFunc, pTrickleFunc, pAnswerOnWebrtcupFunc, pAnsweredFunc, pHungupFunc);
+			pJoinedFunc, pAcceptedFunc, pTrickleFunc, pAnswerOnWebrtcupFunc, pAnsweredFunc, pHungupFunc, pParticipantFunc);
 	}
 #endif
 
@@ -1386,7 +1444,7 @@ switch_status_t apiPoll(server_t *pServer, const janus_id_t serverId,
 	pEvent = pJsonResponse ? pJsonResponse->child : NULL;
 	while (pEvent) {
 		cJSON *next = pEvent->next;
-		(void) api_dispatch_poll_event(pEvent, pJoinedFunc, pAcceptedFunc, pTrickleFunc, pAnswerOnWebrtcupFunc, pAnsweredFunc, pHungupFunc);
+		(void) api_dispatch_poll_event(pEvent, pJoinedFunc, pAcceptedFunc, pTrickleFunc, pAnswerOnWebrtcupFunc, pAnsweredFunc, pHungupFunc, pParticipantFunc);
 		pEvent = next;
 	}
 

--- a/api.h
+++ b/api.h
@@ -48,6 +48,10 @@
 #define API_HMAC_DEFAULT_CALL_TTL     7200 /* 2 hours */
 #define API_HMAC_DEFAULT_LIFECYCLE_TTL 300 /* 5 minutes */
 
+/* Reports each audiobridge participant; isSelf marks the local leg's own id, setup is TRUE once the peer's PeerConnection is up. */
+typedef switch_status_t (*api_participant_func_t)(const janus_id_t serverId, const janus_id_t senderId,
+	const char *pParticipantIdStr, const switch_bool_t isSelf, const switch_bool_t setup);
+
 /* Dispatch one Janus event object (HTTP long-poll element or WebSocket text frame). */
 switch_status_t api_dispatch_poll_event(cJSON *pEvent,
 	switch_status_t (*pJoinedFunc)(const janus_id_t serverId, const janus_id_t senderId, const janus_id_t roomId, const janus_id_t participantId),
@@ -55,7 +59,8 @@ switch_status_t api_dispatch_poll_event(cJSON *pEvent,
 	switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
 	switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
 	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
-	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason));
+	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason),
+	api_participant_func_t pParticipantFunc);
 
 janus_id_t apiGetServerId(server_t *pServer);
 switch_status_t apiClaimServerId(server_t *pServer, janus_id_t serverId);
@@ -78,7 +83,8 @@ switch_status_t apiPoll(server_t *pServer, const janus_id_t serverId,
 	switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
 	switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
 	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
-	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason));
+	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason),
+	api_participant_func_t pParticipantFunc);
 
 #endif //_API_H_
 /* For Emacs:

--- a/janus_ws.c
+++ b/janus_ws.c
@@ -180,12 +180,13 @@ typedef struct {
 	switch_bool_t   (*answer_on_webrtcup)(const janus_id_t, const janus_id_t);
 	switch_status_t (*answered)(const janus_id_t, const janus_id_t);
 	switch_status_t (*hungup)(const janus_id_t, const janus_id_t, const char *);
+	api_participant_func_t participant;
 } janus_ws_dispatch_t;
 
 static void janus_ws_dispatch_event(cJSON *root, const janus_ws_dispatch_t *d)
 {
 	(void) api_dispatch_poll_event(root,
-		d->joined, d->accepted, d->trickle, d->answer_on_webrtcup, d->answered, d->hungup);
+		d->joined, d->accepted, d->trickle, d->answer_on_webrtcup, d->answered, d->hungup, d->participant);
 	cJSON_Delete(root);
 }
 
@@ -345,7 +346,8 @@ switch_status_t janus_ws_pump_once(server_t *server, janus_id_t session_id,
 	switch_status_t (*pTrickleFunc)(const janus_id_t, const janus_id_t, const char *),
 	switch_bool_t   (*pAnswerOnWebrtcupFunc)(const janus_id_t, const janus_id_t),
 	switch_status_t (*pAnsweredFunc)(const janus_id_t, const janus_id_t),
-	switch_status_t (*pHungupFunc)(const janus_id_t, const janus_id_t, const char *))
+	switch_status_t (*pHungupFunc)(const janus_id_t, const janus_id_t, const char *),
+	api_participant_func_t pParticipantFunc)
 {
 	janus_ws_ctx_t *ctx = janus_ws_ctx_get(server);
 	janus_ws_dispatch_t dispatch;
@@ -361,6 +363,7 @@ switch_status_t janus_ws_pump_once(server_t *server, janus_id_t session_id,
 	dispatch.answer_on_webrtcup = pAnswerOnWebrtcupFunc;
 	dispatch.answered           = pAnsweredFunc;
 	dispatch.hungup             = pHungupFunc;
+	dispatch.participant        = pParticipantFunc;
 
 	/* Keepalive. Nested RPC re-enters io_mutex (NESTED), then drain happens below. */
 	if (keepalive_interval_us > 0 && session_id && last_activity_ref && *last_activity_ref > 0 &&

--- a/janus_ws.h
+++ b/janus_ws.h
@@ -10,6 +10,7 @@
 #define MOD_JANUS_JANUS_WS_H
 
 #include "servers.h"
+#include "api.h"
 
 #if defined(HAVE_MOD_JANUS_WS)
 
@@ -35,7 +36,8 @@ switch_status_t janus_ws_pump_once(server_t *server, janus_id_t session_id,
 	switch_status_t (*pTrickleFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pCandidate),
 	switch_bool_t (*pAnswerOnWebrtcupFunc)(const janus_id_t serverId, const janus_id_t senderId),
 	switch_status_t (*pAnsweredFunc)(const janus_id_t serverId, const janus_id_t senderId),
-	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason));
+	switch_status_t (*pHungupFunc)(const janus_id_t serverId, const janus_id_t senderId, const char *pReason),
+	api_participant_func_t pParticipantFunc);
 
 #endif /* HAVE_MOD_JANUS_WS */
 

--- a/mod_janus.c
+++ b/mod_janus.c
@@ -88,8 +88,18 @@ struct private_object {
 	char *pSdpBody;
 	char *pSdpCandidates;
 	char isTrickleComplete;
+
+	/* Answer gating (janus-answer-on-participant-ready): defer the SIP answer until a remote participant is ready; guarded by flag_mutex. */
+	char *pParticipantIdStr;
+	switch_bool_t answerGate;
+	switch_bool_t remoteReady;
+	switch_bool_t answerRequested;
+	switch_bool_t answerDone;
+	switch_time_t answerDeadline;
 };
 typedef struct private_object private_t;
+
+#define JANUS_ANSWER_PARTICIPANT_TIMEOUT_MS_DEFAULT 10000
 
 #define JANUS_SYNTAX "janus [debug|status|listgw]"
 #define JANUS_DEBUG_SYNTAX "janus debug [true|false]"
@@ -135,6 +145,20 @@ switch_status_t joined(janus_id_t serverId, janus_id_t senderId, janus_id_t room
 
 	tech_pvt = switch_core_session_get_private(session);
 	switch_assert(tech_pvt);
+
+	if (switch_channel_var_true(channel, "janus-answer-on-participant-ready")) {
+		const char *pTimeout = switch_channel_get_variable(channel, "janus-answer-participant-timeout-ms");
+		int timeoutMs = pTimeout ? atoi(pTimeout) : 0;
+		if (timeoutMs <= 0) {
+			timeoutMs = JANUS_ANSWER_PARTICIPANT_TIMEOUT_MS_DEFAULT;
+		}
+		switch_mutex_lock(tech_pvt->flag_mutex);
+		tech_pvt->answerGate = SWITCH_TRUE;
+		tech_pvt->answerDeadline = switch_time_now() + (switch_time_t) timeoutMs * 1000;
+		switch_mutex_unlock(tech_pvt->flag_mutex);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+			"Answer gating enabled - deferring answer until a remote participant is ready (timeout=%dms)\n", timeoutMs);
+	}
 
 	switch_channel_set_variable(channel, "media_webrtc", "true");
 	switch_channel_set_flag(channel, CF_AUDIO);
@@ -362,6 +386,7 @@ switch_status_t answered(janus_id_t serverId, janus_id_t senderId) {
 	switch_core_session_t *session;
 	switch_channel_t *channel;
 	server_t *pServer;
+	private_t *tech_pvt;
 
 	if (!(pServer = (server_t *) hashFind(&globals.serverIdLookup, serverId))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "No server for serverId=%" SWITCH_UINT64_T_FMT "\n", serverId);
@@ -376,6 +401,25 @@ switch_status_t answered(janus_id_t serverId, janus_id_t senderId) {
 	channel = switch_core_session_get_channel(session);
 	switch_assert(channel);
 
+	tech_pvt = switch_core_session_get_private(session);
+	switch_assert(tech_pvt);
+
+	/* When gating, hold the answer until a remote participant is ready; record that Janus made the leg answerable. */
+	switch_mutex_lock(tech_pvt->flag_mutex);
+	if (tech_pvt->answerDone) {
+		switch_mutex_unlock(tech_pvt->flag_mutex);
+		return SWITCH_STATUS_SUCCESS;
+	}
+	if (tech_pvt->answerGate && !tech_pvt->remoteReady) {
+		tech_pvt->answerRequested = SWITCH_TRUE;
+		switch_mutex_unlock(tech_pvt->flag_mutex);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+			"Answer requested by Janus - deferring until a remote participant is ready\n");
+		return SWITCH_STATUS_SUCCESS;
+	}
+	tech_pvt->answerDone = SWITCH_TRUE;
+	switch_mutex_unlock(tech_pvt->flag_mutex);
+
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Doing answer\n");
 	if (switch_channel_answer(channel) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Channel answer failed.\n");
@@ -384,6 +428,65 @@ switch_status_t answered(janus_id_t serverId, janus_id_t senderId) {
 
 	switch_channel_mark_answered(channel);
 
+	return SWITCH_STATUS_SUCCESS;
+}
+
+/* Records our own id (isSelf) and, when gating is on, releases the deferred answer once a remote participant reaches setup:true. */
+switch_status_t participant(janus_id_t serverId, janus_id_t senderId, const char *pParticipantIdStr,
+		switch_bool_t isSelf, switch_bool_t setup) {
+	switch_core_session_t *session;
+	server_t *pServer;
+	private_t *tech_pvt;
+	switch_bool_t shouldAnswer = SWITCH_FALSE;
+
+	if (!(pServer = (server_t *) hashFind(&globals.serverIdLookup, serverId))) {
+		return SWITCH_STATUS_NOTFOUND;
+	}
+	if (!(session = (switch_core_session_t *) hashFind(&pServer->senderIdLookup, senderId))) {
+		return SWITCH_STATUS_NOTFOUND;
+	}
+
+	tech_pvt = switch_core_session_get_private(session);
+	switch_assert(tech_pvt);
+
+	if (isSelf) {
+		switch_mutex_lock(tech_pvt->flag_mutex);
+		if (!tech_pvt->pParticipantIdStr && pParticipantIdStr) {
+			tech_pvt->pParticipantIdStr = switch_core_session_strdup(session, pParticipantIdStr);
+		}
+		switch_mutex_unlock(tech_pvt->flag_mutex);
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Own participant id=%s\n", pParticipantIdStr ? pParticipantIdStr : "");
+		return SWITCH_STATUS_SUCCESS;
+	}
+
+	switch_mutex_lock(tech_pvt->flag_mutex);
+	if (!tech_pvt->answerGate || tech_pvt->answerDone) {
+		switch_mutex_unlock(tech_pvt->flag_mutex);
+		return SWITCH_STATUS_SUCCESS;
+	}
+	/* Defensive: never let our own participant id satisfy the gate. */
+	if (pParticipantIdStr && tech_pvt->pParticipantIdStr &&
+			!strcmp(pParticipantIdStr, tech_pvt->pParticipantIdStr)) {
+		switch_mutex_unlock(tech_pvt->flag_mutex);
+		return SWITCH_STATUS_SUCCESS;
+	}
+	if (!setup) {
+		switch_mutex_unlock(tech_pvt->flag_mutex);
+		MOD_JANUS_DBG(SWITCH_CHANNEL_LOG, "Remote participant %s present but not yet set up\n",
+			pParticipantIdStr ? pParticipantIdStr : "");
+		return SWITCH_STATUS_SUCCESS;
+	}
+	tech_pvt->remoteReady = SWITCH_TRUE;
+	/* Answer now only if Janus already made the leg answerable; otherwise the upcoming answered() call proceeds. */
+	shouldAnswer = tech_pvt->answerRequested;
+	switch_mutex_unlock(tech_pvt->flag_mutex);
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+		"Remote participant %s is ready - releasing answer\n", pParticipantIdStr ? pParticipantIdStr : "");
+
+	if (shouldAnswer) {
+		return answered(serverId, senderId);
+	}
 	return SWITCH_STATUS_SUCCESS;
 }
 
@@ -534,7 +637,7 @@ static void *SWITCH_THREAD_FUNC server_thread_run(switch_thread_t *pThread, void
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
 				"Janus %s started (id=%" SWITCH_UINT64_T_FMT ")\n", transport_name(pServer), (janus_id_t)serverId);
 
-			if (apiPoll(pServer, serverId, joined, accepted, trickle, answer_on_webrtcup, answered, hungup) != SWITCH_STATUS_SUCCESS) {
+			if (apiPoll(pServer, serverId, joined, accepted, trickle, answer_on_webrtcup, answered, hungup, participant) != SWITCH_STATUS_SUCCESS) {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
 					"Janus %s failed (id=%" SWITCH_UINT64_T_FMT ")\n", transport_name(pServer), (janus_id_t)serverId);
 				if (hashDelete(&globals.serverIdLookup, serverId) != SWITCH_STATUS_SUCCESS) {
@@ -1020,6 +1123,21 @@ static switch_status_t channel_read_frame(switch_core_session_t *session, switch
 // 	tech_pvt->read_frame.flags = SFF_CNG;
 // 	*frame = &tech_pvt->read_frame;
 // 	return SWITCH_STATUS_SUCCESS;
+
+	{
+		/* Answer-gating fallback: answer once the deadline passes so a missing/failed browser cannot wedge the call. */
+		private_t *tech_pvt = switch_core_session_get_private(session);
+		if (tech_pvt && tech_pvt->answerGate && tech_pvt->answerRequested &&
+				!tech_pvt->answerDone && tech_pvt->answerDeadline &&
+				switch_time_now() >= tech_pvt->answerDeadline) {
+			switch_mutex_lock(tech_pvt->flag_mutex);
+			tech_pvt->remoteReady = SWITCH_TRUE;
+			switch_mutex_unlock(tech_pvt->flag_mutex);
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+				"Answer-gating timeout - answering without a confirmed remote participant\n");
+			(void) answered(tech_pvt->serverId, tech_pvt->senderId);
+		}
+	}
 
 	return switch_core_media_read_frame(session, frame, flags, stream_id, SWITCH_MEDIA_TYPE_AUDIO);
 }


### PR DESCRIPTION
## Summary

When a bridged leg joins a Janus audiobridge room, `mod_janus` answers the FreeSWITCH channel as soon as **its own** leg to Janus is ready (SDP answer / `webrtcup`). The answer propagates upstream and the far end (e.g. an AI agent) starts talking immediately — but a WebRTC browser joining the same room directly often hasn't finished its own PeerConnection yet, so it **misses the greeting**.

This adds an opt-in answer-gating mode that holds the SIP answer until a *genuinely remote* participant in the room has negotiated its PeerConnection (`setup:true`).

- The local leg records its **own** participant id and never counts itself toward the gate, so it waits for a real peer, not itself. Works for both numeric and `string_ids` rooms (ids normalised to string).
- Janus already emits the needed events (`audiobridge: joined` for new peers, `audiobridge: event` with `participants[]` on `setup:true`); these were previously logged/ignored and are now surfaced via a new participant callback threaded through both the HTTP long-poll and WebSocket transports.
- A configurable timeout falls back to answering anyway so a missing or failed peer cannot wedge the call.
- Default behaviour is unchanged when the gate is not enabled.

### New channel variables
- `janus-answer-on-participant-ready` — enable gating (default: off)
- `janus-answer-participant-timeout-ms` — fallback timeout in ms (default: 10000)

### Files
- `api.h` / `api.c` — new `api_participant_func_t`, participants-array dispatch, self-id capture, `setup:true` detection; threaded through `apiPoll`.
- `janus_ws.h` / `janus_ws.c` — callback threaded through the WebSocket pump.
- `mod_janus.c` — gate state on the session, gating in `answered()`, new `participant()` callback, timeout fallback tick in `channel_read_frame`.
- `README.md` — documents the two new channel variables.

## Test plan
- [ ] WebRTC browser web-call: confirm the greeting is no longer clipped (the leg waits for the peer to be `setup:true`).
- [ ] Peer already in room before the gated leg joins: it answers promptly (existing participant detected on join).
- [ ] Peer never connects: leg answers after `janus-answer-participant-timeout-ms`.
- [ ] Gate disabled (default): behaviour identical to before.
- [ ] Verify on both HTTP long-poll and WebSocket transports.
